### PR TITLE
Imitate general ControlW behavior

### DIFF
--- a/document.go
+++ b/document.go
@@ -54,7 +54,14 @@ func (d *Document) GetWordBeforeCursor() string {
 	return x[d.FindStartOfPreviousWord():]
 }
 
-// FindStartOfPreviousWord return an index relative to the cursor position
+// GetWordBeforeCursorWithSpace returns the word before the cursor.
+// Unlike GetWordBeforeCursor, it returns string containing space
+func (d *Document) GetWordBeforeCursorWithSpace() string {
+	x := d.TextBeforeCursor()
+	return x[d.FindStartOfPreviousWordWithSpace():]
+}
+
+// FindStartOfPreviousWord returns an index relative to the cursor position
 // pointing to the start of the previous word. Return `None` if nothing was found.
 func (d *Document) FindStartOfPreviousWord() int {
 	// Reverse the text before the cursor, in order to do an efficient backwards search.
@@ -62,6 +69,24 @@ func (d *Document) FindStartOfPreviousWord() int {
 	l := len(x)
 	for i := l; i > 0; i-- {
 		if x[i-1:i] == " " {
+			return i
+		}
+	}
+	return 0
+}
+
+// FindStartOfPreviousWordWithSpace is almost the same as FindStartOfPreviousWord.
+// The only difference is to ignore contiguous spaces.
+func (d *Document) FindStartOfPreviousWordWithSpace() int {
+	// Reverse the text before the cursor, in order to do an efficient backwards search.
+	x := d.TextBeforeCursor()
+	l := len(x)
+	appear := false
+	for i := l; i > 0; i-- {
+		if x[i-1:i] != " " {
+			appear = true
+		}
+		if x[i-1:i] == " " && appear {
 			return i
 		}
 	}

--- a/document_test.go
+++ b/document_test.go
@@ -88,6 +88,35 @@ func TestDocument_GetWordBeforeCursor(t *testing.T) {
 	}
 }
 
+func TestDocument_GetWordBeforeCursorWithSpace(t *testing.T) {
+	pattern := []struct {
+		document *Document
+		expected string
+	}{
+		{
+			document: &Document{
+				Text:           "apple bana ",
+				CursorPosition: len("apple bana "),
+			},
+			expected: "bana ",
+		},
+		{
+			document: &Document{
+				Text:           "apple ",
+				CursorPosition: len("apple "),
+			},
+			expected: "apple ",
+		},
+	}
+
+	for _, p := range pattern {
+		ac := p.document.GetWordBeforeCursorWithSpace()
+		if ac != p.expected {
+			t.Errorf("Should be %#v, got %#v", p.expected, ac)
+		}
+	}
+}
+
 func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 	pattern := []struct {
 		document *Document
@@ -111,6 +140,35 @@ func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 
 	for _, p := range pattern {
 		ac := p.document.FindStartOfPreviousWord()
+		if ac != p.expected {
+			t.Errorf("Should be %#v, got %#v", p.expected, ac)
+		}
+	}
+}
+
+func TestDocument_FindStartOfPreviousWordWithSpace(t *testing.T) {
+	pattern := []struct {
+		document *Document
+		expected int
+	}{
+		{
+			document: &Document{
+				Text:           "apple bana ",
+				CursorPosition: len("apple bana "),
+			},
+			expected: len("apple "),
+		},
+		{
+			document: &Document{
+				Text:           "apple ",
+				CursorPosition: len("apple "),
+			},
+			expected: len(""),
+		},
+	}
+
+	for _, p := range pattern {
+		ac := p.document.FindStartOfPreviousWordWithSpace()
 		if ac != p.expected {
 			t.Errorf("Should be %#v, got %#v", p.expected, ac)
 		}

--- a/emacs.go
+++ b/emacs.go
@@ -103,7 +103,7 @@ var emacsKeyBindings = []KeyBind{
 	{
 		Key: ControlW,
 		Fn: func(buf *Buffer) {
-			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursor())))
+			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursorWithSpace())))
 		},
 	},
 }


### PR DESCRIPTION
FEATURE REQUEST

`_`: current cursor

You can not delete a word if there is a space before the cursor.

```console
>>> get pod _
```

When this change is patched,

```console
>>> get _
```

You can delete the word before cursor even if there is a space after word