### PR TITLE
enable a "live" prompt/prefix via OptionLivePrefix.

### DIFF
--- a/_example/liveprompt/main.go
+++ b/_example/liveprompt/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/c-bata/go-prompt"
+)
+
+var ApplicationState struct {
+	CWD string
+}
+
+func livePrompt() string {
+	return fmt.Sprintf("(%s) >> ", ApplicationState.CWD)
+}
+
+func executor(in string) {
+	ApplicationState.CWD = strings.Split(in, " ")[1]
+}
+
+func completer(in prompt.Document) []prompt.Suggest {
+	s := []prompt.Suggest{
+		{Text: "cd [target]", Description: "change directory to"},
+	}
+	return prompt.FilterHasPrefix(s, in.GetWordBeforeCursor(), true)
+}
+
+func main() {
+	p := prompt.New(
+		executor,
+		completer,
+		prompt.OptionLivePrefix(livePrompt),
+		prompt.OptionTitle("livePrefixPrompt"),
+	)
+	p.Run()
+}

--- a/_example/liveprompt/main.go
+++ b/_example/liveprompt/main.go
@@ -11,10 +11,12 @@ var ApplicationState struct {
 	CWD string
 }
 
+// livePrompt returns our desired prompt.
 func livePrompt() string {
 	return fmt.Sprintf("(%s) >> ", ApplicationState.CWD)
 }
 
+// executor sets ApplicationState.CWD so the current input string
 func executor(in string) {
 	ApplicationState.CWD = strings.Split(in, " ")[1]
 }

--- a/option.go
+++ b/option.go
@@ -38,6 +38,14 @@ func OptionPrefix(x string) Option {
 	}
 }
 
+// OptionLivePrefix to set a custom "live" prompt prefix string. This accepts a function will be called each time the prompt is rendered.
+func OptionLivePrefix(f func() string) Option {
+	return func(p *Prompt) error {
+		p.renderer.livePrefix = f
+		return nil
+	}
+}
+
 func OptionPrefixTextColor(x Color) Option {
 	return func(p *Prompt) error {
 		p.renderer.prefixTextColor = x
@@ -179,6 +187,7 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 		in: &VT100Parser{fd: syscall.Stdin},
 		renderer: &Render{
 			prefix:                       "> ",
+			livePrefix:                   func() string { return "" },
 			out:                          &VT100Writer{fd: syscall.Stdout},
 			prefixTextColor:              Blue,
 			prefixBGColor:                DefaultColor,

--- a/option.go
+++ b/option.go
@@ -38,7 +38,7 @@ func OptionPrefix(x string) Option {
 	}
 }
 
-// OptionLivePrefix to set a custom "live" prompt prefix string. This accepts a function will be called each time the prompt is rendered.
+// OptionLivePrefix to set a dynamic prefix/prompt string. This option accepts a func() string which is then called on each redraw.
 func OptionLivePrefix(f func() string) Option {
 	return func(p *Prompt) error {
 		p.renderer.livePrefix = f

--- a/render.go
+++ b/render.go
@@ -2,11 +2,12 @@ package prompt
 
 // Render to render prompt information from state of Buffer.
 type Render struct {
-	out    ConsoleWriter
-	prefix string
-	title  string
-	row    uint16
-	col    uint16
+	out        ConsoleWriter
+	livePrefix func() string
+	prefix     string
+	title      string
+	row        uint16
+	col        uint16
 	// colors
 	prefixTextColor              Color
 	prefixBGColor                Color
@@ -130,6 +131,12 @@ func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
 
 // Render renders to the console.
 func (r *Render) Render(buffer *Buffer, completion *CompletionManager) {
+
+	// fall back to the default prompt/prefix is livePrefix is not set
+	if p := r.livePrefix(); p != "" {
+		r.prefix = p
+	}
+
 	// Erasing
 	r.out.CursorBackward(int(r.col) + len(buffer.Text()) + len(r.prefix))
 	r.out.EraseDown()

--- a/render.go
+++ b/render.go
@@ -132,11 +132,10 @@ func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
 // Render renders to the console.
 func (r *Render) Render(buffer *Buffer, completion *CompletionManager) {
 
-	// fall back to the default prompt/prefix is livePrefix is not set
+	// fallback to the default static prefix if livePrefix is not specified.
 	if p := r.livePrefix(); p != "" {
 		r.prefix = p
 	}
-
 	// Erasing
 	r.out.CursorBackward(int(r.col) + len(buffer.Text()) + len(r.prefix))
 	r.out.EraseDown()


### PR DESCRIPTION
This PR introduces a new option ("OptionLivePrefix") that accepts a func() string. render.livePrefix is then called on each invocation of the Render method. Giving users the ability to have a prompt/prefix string that changes based on their desired context.

A basic example included in _example/liveprompt