### PR TITLE
read buffered input

### DIFF
--- a/windows_input.go
+++ b/windows_input.go
@@ -49,6 +49,13 @@ func (p *WindowsParser) Read() ([]byte, error) {
 		return []byte{}, err
 	}
 	n := utf8.EncodeRune(buf[:], r)
+	for p.tty.Buffered() {
+		r, err := p.tty.ReadRune()
+		if err != nil {
+			break
+		}
+		n += utf8.EncodeRune(buf[n:], r)
+	}
 	return buf[:n], nil
 }
 

--- a/windows_input.go
+++ b/windows_input.go
@@ -49,7 +49,7 @@ func (p *WindowsParser) Read() ([]byte, error) {
 		return []byte{}, err
 	}
 	n := utf8.EncodeRune(buf[:], r)
-	for p.tty.Buffered() {
+	for p.tty.Buffered() && n < maxReadBytes {
 		r, err := p.tty.ReadRune()
 		if err != nil {
 			break


### PR DESCRIPTION
Current implementation doesn't read whole of key stroke. This change read input which is buffered.

See: https://qiita.com/c-bata/items/54eee079cfe3cda02eee