### PR TITLE
Add option to customize insertion points for completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### What's new?
 
 * Support CJK(Chinese, Japanese and Korean) and Cyrillic characters.
+* Add OptionCompletionWordSeparator(x string) to customize insertion points for completions.
+    * To support this, text query functions by arbitrary word separator are added in Document (please see [here](https://github.com/c-bata/go-prompt/pull/79) for more details).
+* Add FilePathCompleter to complete file path on your system.
 * Add option to customize ascii code key bindings.
 * Add GetWordAfterCursor method in Document.
 * Add SetDisplayAttributes in ConsoleWriter for flexible customizing display attributes.

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/c-bata/go-prompt"
+	"github.com/c-bata/go-prompt/completer"
+)
+
+func executor(in string) {
+	fmt.Println("Your input: " + in)
+}
+
+func main() {
+	c := completer.FilePathCompleter{
+		IgnoreCase: true,
+		Filter: func(fi os.FileInfo, filename string) bool {
+			return fi.IsDir() || strings.HasSuffix(fi.Name(), ".go")
+		},
+	}
+	p := prompt.New(
+		executor,
+		c.Complete,
+		prompt.OptionPrefix(">>> "),
+		prompt.OptionCompletionWordSeparator(completer.FilePathCompletionSeparator),
+	)
+	p.Run()
+}

--- a/completer/file.go
+++ b/completer/file.go
@@ -1,0 +1,87 @@
+package completer
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+
+	"github.com/c-bata/go-prompt"
+)
+
+var (
+	FilePathCompletionSeparator = string([]byte{' ', os.PathSeparator})
+)
+
+// FilePathCompleter is a completer for your local file system.
+type FilePathCompleter struct {
+	Filter        func(fi os.FileInfo, filename string) bool
+	IgnoreCase    bool
+	fileListCache map[string][]prompt.Suggest
+}
+
+func cleanFilePath(path string) (dir, base string, err error) {
+	if path == "" {
+		return ".", "", nil
+	}
+
+	var endsWithSeparator bool
+	if len(path) >= 1 && path[len(path)-1] == os.PathSeparator {
+		endsWithSeparator = true
+	}
+
+	if runtime.GOOS != "windows" && len(path) >= 2 && path[0:2] == "~/" {
+		me, err := user.Current()
+		if err != nil {
+			return "", "", err
+		}
+		path = filepath.Join(me.HomeDir, path[1:])
+	}
+	path = filepath.Clean(os.ExpandEnv(path))
+	dir = filepath.Dir(path)
+	base = filepath.Base(path)
+
+	if endsWithSeparator {
+		dir = path + string(os.PathSeparator) // Append slash(in POSIX) if path ends with slash.
+		base = ""                             // Set empty string if path ends with separator.
+	}
+	return dir, base, nil
+}
+
+// Complete returns suggestions from your local file system.
+func (c *FilePathCompleter) Complete(d prompt.Document) []prompt.Suggest {
+	if c.fileListCache == nil {
+		c.fileListCache = make(map[string][]prompt.Suggest, 4)
+	}
+
+	path := d.GetWordBeforeCursor()
+	dir, base, err := cleanFilePath(path)
+	if err != nil {
+		log.Print("[ERROR] completer: cannot get current user " + err.Error())
+		return nil
+	}
+
+	if cached, ok := c.fileListCache[dir]; ok {
+		return prompt.FilterHasPrefix(cached, base, c.IgnoreCase)
+	}
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		log.Print("[ERROR] completer: cannot read directory items " + err.Error())
+		return nil
+	}
+
+	suggests := make([]prompt.Suggest, 0, len(files))
+	for _, f := range files {
+		if c.Filter != nil && !c.Filter(f, f.Name()) {
+			continue
+		}
+		suggests = append(suggests, prompt.Suggest{Text: f.Name()})
+	}
+	c.fileListCache[dir] = suggests
+	return prompt.FilterHasPrefix(suggests, base, c.IgnoreCase)
+}

--- a/completion.go
+++ b/completion.go
@@ -35,6 +35,7 @@ type CompletionManager struct {
 	completer Completer
 
 	verticalScroll int
+	wordSeparator  string
 }
 
 // GetSelectedSuggestion returns the selected item.

--- a/document_test.go
+++ b/document_test.go
@@ -161,6 +161,7 @@ func TestDocument_GetWordBeforeCursor(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected string
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -168,6 +169,29 @@ func TestDocument_GetWordBeforeCursor(t *testing.T) {
 				cursorPosition: len("apple bana"),
 			},
 			expected: "bana",
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./file/foo.json"),
+			},
+			expected: "foo.json",
+			sep:      " /",
+		},
+		{
+			document: &Document{
+				Text:           "apple banana orange",
+				cursorPosition: len("apple ba"),
+			},
+			expected: "ba",
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./fi"),
+			},
+			expected: "fi",
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -193,9 +217,20 @@ func TestDocument_GetWordBeforeCursor(t *testing.T) {
 	}
 
 	for i, p := range pattern {
-		ac := p.document.GetWordBeforeCursor()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.GetWordBeforeCursor()
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
+			}
+			ac = p.document.GetWordBeforeCursorUntilSeparator("")
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
+			}
+		} else {
+			ac := p.document.GetWordBeforeCursorUntilSeparator(p.sep)
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", i, p.expected, ac)
+			}
 		}
 	}
 }
@@ -204,6 +239,7 @@ func TestDocument_GetWordBeforeCursorWithSpace(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected string
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -214,10 +250,26 @@ func TestDocument_GetWordBeforeCursorWithSpace(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "apply -f /path/to/file/",
+				cursorPosition: len("apply -f /path/to/file/"),
+			},
+			expected: "file/",
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple ",
 				cursorPosition: len("apple "),
 			},
 			expected: "apple ",
+		},
+		{
+			document: &Document{
+				Text:           "path/",
+				cursorPosition: len("path/"),
+			},
+			expected: "path/",
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -236,9 +288,20 @@ func TestDocument_GetWordBeforeCursorWithSpace(t *testing.T) {
 	}
 
 	for _, p := range pattern {
-		ac := p.document.GetWordBeforeCursorWithSpace()
-		if ac != p.expected {
-			t.Errorf("Should be %#v, got %#v", p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.GetWordBeforeCursorWithSpace()
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+			ac = p.document.GetWordBeforeCursorUntilSeparatorIgnoreNextToCursor("")
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+		} else {
+			ac := p.document.GetWordBeforeCursorUntilSeparatorIgnoreNextToCursor(p.sep)
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
 		}
 	}
 }
@@ -247,6 +310,7 @@ func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected int
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -257,10 +321,26 @@ func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./file/foo.json"),
+			},
+			expected: len("apply -f ./file/"),
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple ",
 				cursorPosition: len("apple "),
 			},
 			expected: len("apple "),
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./"),
+			},
+			expected: len("apply -f ./"),
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -279,9 +359,20 @@ func TestDocument_FindStartOfPreviousWord(t *testing.T) {
 	}
 
 	for _, p := range pattern {
-		ac := p.document.FindStartOfPreviousWord()
-		if ac != p.expected {
-			t.Errorf("Should be %#v, got %#v", p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.FindStartOfPreviousWord()
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+			ac = p.document.FindStartOfPreviousWordUntilSeparator("")
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+		} else {
+			ac := p.document.FindStartOfPreviousWordUntilSeparator(p.sep)
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
 		}
 	}
 }
@@ -290,6 +381,7 @@ func TestDocument_FindStartOfPreviousWordWithSpace(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected int
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -300,10 +392,26 @@ func TestDocument_FindStartOfPreviousWordWithSpace(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "apply -f /file/foo/",
+				cursorPosition: len("apply -f /file/foo/"),
+			},
+			expected: len("apply -f /file/"),
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple ",
 				cursorPosition: len("apple "),
 			},
 			expected: len(""),
+		},
+		{
+			document: &Document{
+				Text:           "file/",
+				cursorPosition: len("file/"),
+			},
+			expected: len(""),
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -322,9 +430,20 @@ func TestDocument_FindStartOfPreviousWordWithSpace(t *testing.T) {
 	}
 
 	for _, p := range pattern {
-		ac := p.document.FindStartOfPreviousWordWithSpace()
-		if ac != p.expected {
-			t.Errorf("Should be %#v, got %#v", p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.FindStartOfPreviousWordWithSpace()
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+			ac = p.document.FindStartOfPreviousWordUntilSeparatorIgnoreNextToCursor("")
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
+		} else {
+			ac := p.document.FindStartOfPreviousWordUntilSeparatorIgnoreNextToCursor(p.sep)
+			if ac != p.expected {
+				t.Errorf("Should be %#v, got %#v", p.expected, ac)
+			}
 		}
 	}
 }
@@ -333,6 +452,7 @@ func TestDocument_GetWordAfterCursor(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected string
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -340,6 +460,14 @@ func TestDocument_GetWordAfterCursor(t *testing.T) {
 				cursorPosition: len("apple bana"),
 			},
 			expected: "",
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./fi"),
+			},
+			expected: "le",
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -354,6 +482,14 @@ func TestDocument_GetWordAfterCursor(t *testing.T) {
 				cursorPosition: len("apple"),
 			},
 			expected: "",
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ."),
+			},
+			expected: "",
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -379,9 +515,20 @@ func TestDocument_GetWordAfterCursor(t *testing.T) {
 	}
 
 	for k, p := range pattern {
-		ac := p.document.GetWordAfterCursor()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.GetWordAfterCursor()
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+			ac = p.document.GetWordAfterCursorUntilSeparator("")
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+		} else {
+			ac := p.document.GetWordAfterCursorUntilSeparator(p.sep)
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
 		}
 	}
 }
@@ -390,6 +537,7 @@ func TestDocument_GetWordAfterCursorWithSpace(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected string
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -407,10 +555,34 @@ func TestDocument_GetWordAfterCursorWithSpace(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "/path/to",
+				cursorPosition: len("/path/"),
+			},
+			expected: "to",
+			sep:      " /",
+		},
+		{
+			document: &Document{
+				Text:           "/path/to/file",
+				cursorPosition: len("/path/"),
+			},
+			expected: "to",
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple bana",
 				cursorPosition: len("apple"),
 			},
 			expected: " bana",
+		},
+		{
+			document: &Document{
+				Text:           "path/to",
+				cursorPosition: len("path"),
+			},
+			expected: "/to",
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -436,9 +608,20 @@ func TestDocument_GetWordAfterCursorWithSpace(t *testing.T) {
 	}
 
 	for k, p := range pattern {
-		ac := p.document.GetWordAfterCursorWithSpace()
-		if ac != p.expected {
-			t.Errorf("[%d]Should be %#v, got %#v", k, p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.GetWordAfterCursorWithSpace()
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+			ac = p.document.GetWordAfterCursorUntilSeparatorIgnoreNextToCursor("")
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+		} else {
+			ac := p.document.GetWordAfterCursorUntilSeparatorIgnoreNextToCursor(p.sep)
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
 		}
 	}
 }
@@ -447,6 +630,7 @@ func TestDocument_FindEndOfCurrentWord(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected int
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -464,10 +648,26 @@ func TestDocument_FindEndOfCurrentWord(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ./"),
+			},
+			expected: len("file"),
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple bana",
 				cursorPosition: len("apple"),
 			},
 			expected: len(""),
+		},
+		{
+			document: &Document{
+				Text:           "apply -f ./file/foo.json",
+				cursorPosition: len("apply -f ."),
+			},
+			expected: len(""),
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -502,9 +702,20 @@ func TestDocument_FindEndOfCurrentWord(t *testing.T) {
 	}
 
 	for k, p := range pattern {
-		ac := p.document.FindEndOfCurrentWord()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.FindEndOfCurrentWord()
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+			ac = p.document.FindEndOfCurrentWordUntilSeparator("")
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+		} else {
+			ac := p.document.FindEndOfCurrentWordUntilSeparator(p.sep)
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
 		}
 	}
 }
@@ -513,6 +724,7 @@ func TestDocument_FindEndOfCurrentWordWithSpace(t *testing.T) {
 	pattern := []struct {
 		document *Document
 		expected int
+		sep      string
 	}{
 		{
 			document: &Document{
@@ -530,10 +742,26 @@ func TestDocument_FindEndOfCurrentWordWithSpace(t *testing.T) {
 		},
 		{
 			document: &Document{
+				Text:           "apply -f /file/foo.json",
+				cursorPosition: len("apply -f /"),
+			},
+			expected: len("file"),
+			sep:      " /",
+		},
+		{
+			document: &Document{
 				Text:           "apple bana",
 				cursorPosition: len("apple"),
 			},
 			expected: len(" bana"),
+		},
+		{
+			document: &Document{
+				Text:           "apply -f /path/to",
+				cursorPosition: len("apply -f /path"),
+			},
+			expected: len("/to"),
+			sep:      " /",
 		},
 		{
 			document: &Document{
@@ -566,9 +794,20 @@ func TestDocument_FindEndOfCurrentWordWithSpace(t *testing.T) {
 	}
 
 	for k, p := range pattern {
-		ac := p.document.FindEndOfCurrentWordWithSpace()
-		if ac != p.expected {
-			t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+		if p.sep == "" {
+			ac := p.document.FindEndOfCurrentWordWithSpace()
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+			ac = p.document.FindEndOfCurrentWordUntilSeparatorIgnoreNextToCursor("")
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
+		} else {
+			ac := p.document.FindEndOfCurrentWordUntilSeparatorIgnoreNextToCursor(p.sep)
+			if ac != p.expected {
+				t.Errorf("[%d] Should be %#v, got %#v", k, p.expected, ac)
+			}
 		}
 	}
 }

--- a/option.go
+++ b/option.go
@@ -36,6 +36,14 @@ func OptionPrefix(x string) Option {
 	}
 }
 
+// OptionCompletionWordSeparator to set word separators. Enable only ' ' if empty.
+func OptionCompletionWordSeparator(x string) Option {
+	return func(p *Prompt) error {
+		p.completion.wordSeparator = x
+		return nil
+	}
+}
+
 // OptionLivePrefix to change the prefix dynamically by callback function
 func OptionLivePrefix(f func() (prefix string, useLivePrefix bool)) Option {
 	return func(p *Prompt) error {

--- a/prompt.go
+++ b/prompt.go
@@ -170,7 +170,7 @@ func (p *Prompt) handleCompletionKeyBinding(key Key, completing bool) {
 		p.completion.Previous()
 	default:
 		if s, ok := p.completion.GetSelectedSuggestion(); ok {
-			w := p.buf.Document().GetWordBeforeCursor()
+			w := p.buf.Document().GetWordBeforeCursorUntilSeparator(p.completion.wordSeparator)
 			if w != "" {
 				p.buf.DeleteBeforeCursor(len([]rune(w)))
 			}

--- a/render.go
+++ b/render.go
@@ -207,7 +207,7 @@ func (r *Render) Render(buffer *Buffer, completion *CompletionManager) {
 
 	r.renderCompletion(buffer, completion)
 	if suggest, ok := completion.GetSelectedSuggestion(); ok {
-		cursor = r.backward(cursor, runewidth.StringWidth(buffer.Document().GetWordBeforeCursor()))
+		cursor = r.backward(cursor, runewidth.StringWidth(buffer.Document().GetWordBeforeCursorUntilSeparator(completion.wordSeparator)))
 
 		r.out.SetColor(r.previewSuggestionTextColor, r.previewSuggestionBGColor, false)
 		r.out.WriteStr(suggest.Text)


### PR DESCRIPTION
## Summary

This PR fixed https://github.com/c-bata/go-prompt/issues/53

By using this feature, we can complete items which is not only separated by space. For example, we can complete files on your local machine like:

![file_completer](https://user-images.githubusercontent.com/5564044/41810190-19bd1cee-7735-11e8-961c-32b19a0a704d.gif)

## What should we define as default word separators

In https://github.com/c-bata/go-prompt/issues/66, Chyroc suggest that "," should have the same effect with ` `. I checked bash-shell's word separator by running `Ctrl + W` (Cut the word before the cursor) after input following text which includes `space`, `comma`, `period`, `colon`, `semi-colon` and `em space`.

```
$ abc def,hij.klm;opq　rsu:vwx
                            . <- cursor is here
```

then `Ctrl + W` removes until space. The result is below:

```
$ abc
    .
```

From this behavior, I think we should only set `space` as a default word separator. This is the same as ever.

## Interface design (still not implemented)

There is the scene to customize word separator.

**Add `prompt.OptionCompletionWordSeparator(x string)`** for https://github.com/c-bata/go-prompt/issues/53 and https://github.com/c-bata/go-prompt/issues/61.

These methods are used when we want to change the insertion points for completer.

```go
func main() {
	p := prompt.New(
		executor,
		completer,
		prompt.OptionPrefix(">>> "),
		prompt.OptionCompletionWordSeparator(" /"),
	)
	p.Run()
}
```

**Provide text query functions by arbitrary word separator for https://github.com/c-bata/go-prompt/issues/66

These methods are available from KeyBind functions like:

```go
var emacsKeyBindings = []KeyBind{
	// Cut the Word before the cursor.
	{
		Key: ControlW,
		Fn: func(buf *Buffer) {
			buf.DeleteBeforeCursor(
				len([]rune(buf.Document(). GetWordBeforeCursorUntilSeparatorIgnoreNextToCursor(" ,")))
			)
		},
	},
        ...
}
```
