### PR TITLE
Delete break line characters from Suggests

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -108,6 +108,12 @@ func (c *CompletionManager) update() {
 	}
 }
 
+func deleteBreakLineCharacters(s string) string {
+	s = strings.Replace(s, "\n", "", -1)
+	s = strings.Replace(s, "\r", "", -1)
+	return s
+}
+
 func formatTexts(o []string, max int, prefix, suffix string) (new []string, width int) {
 	l := len(o)
 	n := make([]string, l)
@@ -117,6 +123,8 @@ func formatTexts(o []string, max int, prefix, suffix string) (new []string, widt
 	lenShorten := runewidth.StringWidth(shortenSuffix)
 	min := lenPrefix + lenSuffix + lenShorten
 	for i := 0; i < l; i++ {
+		o[i] = deleteBreakLineCharacters(o[i])
+
 		w := runewidth.StringWidth(o[i])
 		if width < w {
 			width = w


### PR DESCRIPTION
Fixes https://github.com/c-bata/go-prompt/issues/64

I confirmed this changes works fine on a following script:

```go
package main

import (
	"fmt"

	"github.com/c-bata/go-prompt"
)

func executor(in string) {
	fmt.Println("Your input: " + in)
}

func completer(in prompt.Document) []prompt.Suggest {
	s := []prompt.Suggest{
		{Text: "users", Description: "Store the\n username and age"},
		{Text: "articles", Description: "Store the\r article text posted by user"},
	}
	return prompt.FilterHasPrefix(s, in.GetWordBeforeCursor(), true)
}

func main() {
	p := prompt.New(
		executor,
		completer,
	)
	p.Run()
}
```