### PR TITLE
History Get function added

### DIFF
--- a/history.go
+++ b/history.go
@@ -54,6 +54,9 @@ func (h *History) Newer(buf *Buffer) (new *Buffer, changed bool) {
 
 // Get x lines back in the history as a string array
 func (h *History) Get(lines int) []string {
+    if lines > len(h.histories) {
+        lines = len(h.histories)
+    }
     return h.histories[h.selected - lines:h.selected]
 }
 

--- a/history.go
+++ b/history.go
@@ -1,5 +1,6 @@
 package prompt
 
+
 // History stores the texts that are entered.
 type History struct {
 	histories []string
@@ -49,6 +50,11 @@ func (h *History) Newer(buf *Buffer) (new *Buffer, changed bool) {
 	new = NewBuffer()
 	new.InsertText(h.tmp[h.selected], false, true)
 	return new, true
+}
+
+// Get x lines back in the history as a string array
+func (h *History) Get(lines int) []string {
+    return h.histories[h.selected - lines:h.selected]
 }
 
 // NewHistory returns new history object.

--- a/history_test.go
+++ b/history_test.go
@@ -84,5 +84,10 @@ func TestHistoryGet(t *testing.T) {
 	if !reflect.DeepEqual(expectedGet3, returnGet) {
 		t.Errorf("History.Get(3) returned %s, expected %s", returnGet, expectedGet3)
 	}
+
+	returnGet = h.Get(5)
+	if !reflect.DeepEqual(expectedGet3, returnGet) {
+		t.Errorf("History.Get(5) returned %s, expected %s", returnGet, expectedGet3)
+	}
 	
 }

--- a/history_test.go
+++ b/history_test.go
@@ -85,6 +85,8 @@ func TestHistoryGet(t *testing.T) {
 		t.Errorf("History.Get(3) returned %s, expected %s", returnGet, expectedGet3)
 	}
 
+	// make sure requesting more lines than
+	// there are history entries does not fail
 	returnGet = h.Get(5)
 	if !reflect.DeepEqual(expectedGet3, returnGet) {
 		t.Errorf("History.Get(5) returned %s, expected %s", returnGet, expectedGet3)

--- a/history_test.go
+++ b/history_test.go
@@ -60,3 +60,29 @@ func TestHistoryOlder(t *testing.T) {
 		t.Errorf("Should be %#v, but got %#v", "echo 1", buf2.Text())
 	}
 }
+
+func TestHistoryGet(t *testing.T) {
+	h := NewHistory()
+	h.Add("echo 1")
+	h.Add("echo 2")
+	h.Add("echo 3")
+	expectedGet2 := []string{
+		"echo 2",
+		"echo 3",
+	}
+	returnGet := h.Get(2)
+	if !reflect.DeepEqual(expectedGet2, returnGet) {
+		t.Errorf("History.Get(2) return %s, expected %s", returnGet, expectedGet2)
+	}
+
+	expectedGet3 := []string{
+		"echo 1",
+		"echo 2",
+		"echo 3",
+	}
+	returnGet = h.Get(3)
+	if !reflect.DeepEqual(expectedGet3, returnGet) {
+		t.Errorf("History.Get(3) returned %s, expected %s", returnGet, expectedGet3)
+	}
+	
+}


### PR DESCRIPTION
Added a history.Get function to return x lines back in the history as a string slice.  I find this func useful for dealing with history in the command shell.  I was looping through older/newer before adding this and it simplified things a lot for me.  Added a test to make sure it's working as expected.