### PR TITLE
Update CHANGELOG for v0.2.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## v0.2.2 (2018/??/??)
+## v0.3.0 (2018/??/??)
+
+next release.
+
+## v0.2.2 (2018/06/28)
 
 ### What's new?
 
@@ -10,11 +14,6 @@
 * Add FilePathCompleter to complete file path on your system.
 * Add option to customize ascii code key bindings.
 * Add GetWordAfterCursor method in Document.
-* Add SetDisplayAttributes in ConsoleWriter for flexible customizing display attributes.
-
-### Fixed
-
-* Fix a bug in docker container [issue #39](https://github.com/c-bata/go-prompt/issues/39)
 
 ### Removed or Deprecated
 

--- a/document.go
+++ b/document.go
@@ -125,9 +125,8 @@ func (d *Document) FindStartOfPreviousWord() int {
 	i := strings.LastIndexByte(x, ' ')
 	if i != -1 {
 		return i + 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // FindStartOfPreviousWordWithSpace is almost the same as FindStartOfPreviousWord.
@@ -157,9 +156,8 @@ func (d *Document) FindStartOfPreviousWordUntilSeparator(sep string) int {
 	i := strings.LastIndexAny(x, sep)
 	if i != -1 {
 		return i + 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // FindStartOfPreviousWordUntilSeparatorIgnoreNextToCursor is almost the same as FindStartOfPreviousWordWithSpace.
@@ -188,9 +186,8 @@ func (d *Document) FindEndOfCurrentWord() int {
 	i := strings.IndexByte(x, ' ')
 	if i != -1 {
 		return i
-	} else {
-		return len(x)
 	}
+	return len(x)
 }
 
 // FindEndOfCurrentWordWithSpace is almost the same as FindEndOfCurrentWord.
@@ -222,9 +219,8 @@ func (d *Document) FindEndOfCurrentWordUntilSeparator(sep string) int {
 	i := strings.IndexAny(x, sep)
 	if i != -1 {
 		return i
-	} else {
-		return len(x)
 	}
+	return len(x)
 }
 
 // FindEndOfCurrentWordUntilSeparatorIgnoreNextToCursor is almost the same as FindEndOfCurrentWordWithSpace.

--- a/key_bind_func.go
+++ b/key_bind_func.go
@@ -1,6 +1,6 @@
 package prompt
 
-// CursorLineEnd Go to the End of the line
+// GoLineEnd Go to the End of the line
 func GoLineEnd(buf *Buffer) {
 	x := []rune(buf.Document().TextAfterCursor())
 	buf.CursorRight(len(x))

--- a/option.go
+++ b/option.go
@@ -217,7 +217,7 @@ func OptionAddKeyBind(b ...KeyBind) Option {
 	}
 }
 
-// OptionAddKeyBind to set a custom key bind.
+// OptionAddASCIICodeBind to set a custom key bind.
 func OptionAddASCIICodeBind(b ...ASCIICodeBind) Option {
 	return func(p *Prompt) error {
 		p.ASCIICodeBindings = append(p.ASCIICodeBindings, b...)

--- a/output.go
+++ b/output.go
@@ -16,7 +16,7 @@ const (
 	DisplayUnderline
 	// DisplayBlink set blink (less than 150 per minute).
 	DisplayBlink
-	// DisplayBlink set blink (more than 150 per minute). Not widely supported.
+	// DisplayRapidBlink set blink (more than 150 per minute). Not widely supported.
 	DisplayRapidBlink
 	// DisplayReverse swap foreground and background colors.
 	DisplayReverse
@@ -144,8 +144,5 @@ type ConsoleWriter interface {
 	/* Font */
 
 	// SetColor sets text and background colors. and specify whether text is bold.
-	// Deprecated. This interface is not cool, please use SetDisplayAttributes.
 	SetColor(fg, bg Color, bold bool)
-	// SetDisplayAttributes set display attributes (Set colors, blink, bold, italic and so on).
-	SetDisplayAttributes(fg, bg Color, attrs ...DisplayAttribute)
 }

--- a/output_vt100.go
+++ b/output_vt100.go
@@ -232,7 +232,6 @@ func (w *VT100Writer) ClearTitle() {
 /* Font */
 
 // SetColor sets text and background colors. and specify whether text is bold.
-// Deprecated. This interface is not cool, please use SetDisplayAttributes.
 func (w *VT100Writer) SetColor(fg, bg Color, bold bool) {
 	if bold {
 		w.SetDisplayAttributes(fg, bg, DisplayBold)
@@ -242,7 +241,7 @@ func (w *VT100Writer) SetColor(fg, bg Color, bold bool) {
 	return
 }
 
-// SetDisplayAttributes set display attributes (Set colors, blink, bold, italic and so on).
+// SetDisplayAttributes to set VT100 display attributes.
 func (w *VT100Writer) SetDisplayAttributes(fg, bg Color, attrs ...DisplayAttribute) {
 	w.WriteRaw([]byte{0x1b, '['}) // control sequence introducer
 	defer w.WriteRaw([]byte{'m'}) // final character


### PR DESCRIPTION
https://github.com/c-bata/go-prompt/pull/83 has a breaking api changes for users who customize ConsoleParser or ConsoleWriter. So I tagged v0.2.2 on current implementation on master branch.
I confirmed this release works fine on following terminal emulators.

* iTerm2(macOS)
* Command prompt (Windows 10)