### PR TITLE
Fix resetting display attributes on VT100 output

### DIFF
--- a/output_vt100.go
+++ b/output_vt100.go
@@ -236,7 +236,7 @@ func (w *VT100Writer) SetColor(fg, bg Color, bold bool) {
 	if bold {
 		w.SetDisplayAttributes(fg, bg, DisplayBold)
 	} else {
-		w.SetDisplayAttributes(fg, bg, DisplayDefaultFont)
+		w.SetDisplayAttributes(fg, bg, DisplayDefaultFont, DisplayReset)
 	}
 	return
 }


### PR DESCRIPTION
I'm using go-prompt on urxvt on Arch Linux and I'm running into an issue where the bold attribute isn't being reset correctly after its first use.  I don't know a lot about ANSI/VT100 but I wasn't able to find the '10' attribute that was currently being used, so I added the '0' attribute in addition to it.  This fixed the bold not being reset on my terminal.

I haven't had a chance to test on Windows, Mac or the Gnome Terminal yet.