### PR TITLE
Modify flush in writer

### DIFF
--- a/output_posix.go
+++ b/output_posix.go
@@ -3,8 +3,11 @@
 package prompt
 
 import (
+	"log"
 	"syscall"
 )
+
+const flushMaxRetryCount = 3
 
 // PosixWriter is a ConsoleWriter implementation for POSIX environment.
 // To control terminal emulator, this outputs VT100 escape sequences.
@@ -17,9 +20,15 @@ type PosixWriter struct {
 func (w *PosixWriter) Flush() error {
 	l := len(w.buffer)
 	offset := 0
+	retry := 0
 	for {
 		n, err := syscall.Write(w.fd, w.buffer[offset:])
 		if err != nil {
+			log.Printf("[DEBUG] flush error: %s", err)
+			if retry < flushMaxRetryCount {
+				retry++
+				continue
+			}
 			return err
 		}
 		offset += n

--- a/output_posix.go
+++ b/output_posix.go
@@ -15,9 +15,17 @@ type PosixWriter struct {
 
 // Flush to flush buffer
 func (w *PosixWriter) Flush() error {
-	_, err := syscall.Write(w.fd, w.buffer)
-	if err != nil {
-		return err
+	l := len(w.buffer)
+	offset := 0
+	for {
+		n, err := syscall.Write(w.fd, w.buffer[offset:])
+		if err != nil {
+			return err
+		}
+		offset += n
+		if offset == l {
+			break
+		}
 	}
 	w.buffer = []byte{}
 	return nil


### PR DESCRIPTION
Sometimes write system call returned "resource temporarily unavailable" in go-prompt. I don't know why but probably the reason might that terminal mode was changed in my unexpected trigger. Anyway, It will be fixed to retry syscall.Write.

related issue is https://github.com/c-bata/kube-prompt/issues/29