### PR TITLE
Add godoc badge to README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/c-bata/go-prompt)](https://goreportcard.com/report/github.com/c-bata/go-prompt)
 ![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)
-[![Backers on Open Collective](https://opencollective.com/go-prompt/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/go-prompt/sponsors/badge.svg)](#sponsors) 
+[![Backers on Open Collective](https://opencollective.com/go-prompt/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/go-prompt/sponsors/badge.svg)](#sponsors)
+[![GoDoc](https://godoc.org/github.com/c-bata/go-prompt?status.svg)](https://godoc.org/github.com/c-bata/go-prompt) 
 
 A library for building powerful interactive prompts inspired by [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit),
 making it easier to build cross-platform command line tools using Go.


### PR DESCRIPTION
Like other famous package such as [pkg/errors](https://github.com/pkg/errors), adding badge link to documentation would help people to find out the documentation from GitHub README page easily.
This is just a suggestion from me so please feel free to reject this if you don't think so.