### PR TITLE
Fix test on macOS

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -26,6 +26,10 @@ func TestDocument_DisplayCursorPosition(t *testing.T) {
 			expected: 4,
 		},
 		{
+			// If you're facing test failure on this test case and your terminal is iTerm2,
+			// please check 'Profile -> Text' configuration. 'Use Unicode version 9 widths'
+			// must be checked.
+			// https://github.com/c-bata/go-prompt/pull/99
 			document: &Document{
 				Text:           "Добрый день",
 				cursorPosition: 3,


### PR DESCRIPTION
Characters in `Добрый день` are actually double-width on macOS terminals (confirmed on Terminal.app and iTerm2.app).

![2018-10-18 19 47 34](https://user-images.githubusercontent.com/823277/47149318-33641500-d30e-11e8-9f02-365fc3f466a3.png)

It caused test failure and I fixed it by modifying expected value. (I'm not sure updated *expected* value is actually what you expect, tho...)