### PR TITLE
Add option to show completion at start on Prompt.Input()

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -36,6 +36,7 @@ type CompletionManager struct {
 
 	verticalScroll int
 	wordSeparator  string
+	showAtStart    bool
 }
 
 // GetSelectedSuggestion returns the selected item.

--- a/option.go
+++ b/option.go
@@ -226,6 +226,14 @@ func OptionAddASCIICodeBind(b ...ASCIICodeBind) Option {
 	}
 }
 
+// OptionShowCompletionAtStart to set completion window is open at start.
+func OptionShowCompletionAtStart() Option {
+	return func(p *Prompt) error {
+		p.completion.showAtStart = true
+		return nil
+	}
+}
+
 // New returns a Prompt with powerful auto-completion.
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	defaultWriter := NewStdoutWriter()

--- a/prompt.go
+++ b/prompt.go
@@ -51,6 +51,10 @@ func (p *Prompt) Run() {
 	p.setUp()
 	defer p.tearDown()
 
+	if p.completion.showAtStart {
+		p.completion.Update(*p.buf.Document())
+	}
+
 	p.renderer.Render(p.buf, p.completion)
 
 	bufCh := make(chan []byte, 128)
@@ -231,6 +235,10 @@ func (p *Prompt) Input() string {
 
 	p.setUp()
 	defer p.tearDown()
+
+	if p.completion.showAtStart {
+		p.completion.Update(*p.buf.Document())
+	}
 
 	p.renderer.Render(p.buf, p.completion)
 	bufCh := make(chan []byte, 128)


### PR DESCRIPTION
I'm using this library for `Prompt.Call` to choose one from several candidates.

The pain point for me was no completion window is not shown at start. Users cannot notice that it supports completion until they input first character. However, in context where users choose one of candidates, they need to know what character should be input at first. However they can't since there is no candidate shown at start.

So I added one small option `OptionShowCompletionAtStart` to show completion just after starting selection, which is disabled by default. I could not add any test for this since there is no test for `prompt.Input` and `prompt.Option*`.

I've just started to use this library. So it may be possible to do that without adding a new option. In the case, I'll be happy if you kindly tell how to do that.