### PR TITLE
Enable to use stderr as output with option

### DIFF
--- a/option.go
+++ b/option.go
@@ -225,6 +225,14 @@ func OptionAddASCIICodeBind(b ...ASCIICodeBind) Option {
 	}
 }
 
+// OptionUseStderr to set stderr as output
+func OptionUseStderr() Option {
+	return func(p *Prompt) error {
+		p.renderer.out.UseStderr()
+		return nil
+	}
+}
+
 // New returns a Prompt with powerful auto-completion.
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	pt := &Prompt{

--- a/output.go
+++ b/output.go
@@ -145,4 +145,7 @@ type ConsoleWriter interface {
 
 	// SetColor sets text and background colors. and specify whether text is bold.
 	SetColor(fg, bg Color, bold bool)
+
+	// UseStderr sets stderr as output
+	UseStderr()
 }

--- a/output_posix.go
+++ b/output_posix.go
@@ -40,6 +40,11 @@ func (w *PosixWriter) Flush() error {
 	return nil
 }
 
+// UseStderr to set stderr as output
+func (w *PosixWriter) UseStderr() {
+	w.fd = syscall.Stderr
+}
+
 var _ ConsoleWriter = &PosixWriter{}
 
 // NewStandardOutputWriter returns ConsoleWriter object to write to stdout.

--- a/output_vt100.go
+++ b/output_vt100.go
@@ -270,6 +270,11 @@ func (w *VT100Writer) SetDisplayAttributes(fg, bg Color, attrs ...DisplayAttribu
 	return
 }
 
+// UseStderr to set stderr as output
+func (w *VT100Writer) UseStderr() {
+	// Do nothing
+}
+
 var displayAttributeParameters = map[DisplayAttribute][]byte{
 	DisplayReset:        {'0'},
 	DisplayBold:         {'1'},

--- a/output_windows.go
+++ b/output_windows.go
@@ -25,6 +25,11 @@ func (w *WindowsWriter) Flush() error {
 	return nil
 }
 
+// UseStderr to set stderr as output
+func (w *WindowsWriter) UseStderr() {
+	w.out = colorable.NewColorableStderr()
+}
+
 var _ ConsoleWriter = &WindowsWriter{}
 
 // NewStandardOutputWriter returns ConsoleWriter object to write to stdout.


### PR DESCRIPTION
Current go-prompt outputs a prompt to stdout. However, it has trouble with pipe. For example, when `my-app` command is piped to `peco` as follows:

```
$ my-app | peco
```

stdout is redirected to `peco` and propmts are not shown in terminal. To avoid this, stderr should be used in this case.

In this PR, I added `OptionUseStderr` to change output to stderr (disabled by default).