### PR TITLE
Add NewStderrWriter

### DIFF
--- a/option.go
+++ b/option.go
@@ -228,7 +228,7 @@ func OptionAddASCIICodeBind(b ...ASCIICodeBind) Option {
 
 // New returns a Prompt with powerful auto-completion.
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
-	defaultWriter := NewStandardOutputWriter()
+	defaultWriter := NewStdoutWriter()
 	registerConsoleWriter(defaultWriter)
 
 	pt := &Prompt{

--- a/output_posix.go
+++ b/output_posix.go
@@ -42,11 +42,25 @@ func (w *PosixWriter) Flush() error {
 
 var _ ConsoleWriter = &PosixWriter{}
 
-// NewStandardOutputWriter returns ConsoleWriter object to write to stdout.
+var (
+	// Deprecated: Please use NewStdoutWriter
+	NewStandardOutputWriter = NewStdoutWriter
+)
+
+// NewStdoutWriter returns ConsoleWriter object to write to stdout.
 // This generates VT100 escape sequences because almost terminal emulators
 // in POSIX OS built on top of a VT100 specification.
-func NewStandardOutputWriter() ConsoleWriter {
+func NewStdoutWriter() ConsoleWriter {
 	return &PosixWriter{
 		fd: syscall.Stdout,
+	}
+}
+
+// NewStderrWriter returns ConsoleWriter object to write to stderr.
+// This generates VT100 escape sequences because almost terminal emulators
+// in POSIX OS built on top of a VT100 specification.
+func NewStderrWriter() ConsoleWriter {
+	return &PosixWriter{
+		fd: syscall.Stderr,
 	}
 }

--- a/output_windows.go
+++ b/output_windows.go
@@ -27,10 +27,23 @@ func (w *WindowsWriter) Flush() error {
 
 var _ ConsoleWriter = &WindowsWriter{}
 
-// NewStandardOutputWriter returns ConsoleWriter object to write to stdout.
+var (
+	// Deprecated: Please use NewStdoutWriter
+	NewStandardOutputWriter = NewStdoutWriter
+)
+
+// NewStdoutWriter returns ConsoleWriter object to write to stdout.
 // This generates win32 control sequences.
-func NewStandardOutputWriter() ConsoleWriter {
+func NewStdoutWriter() ConsoleWriter {
 	return &WindowsWriter{
 		out: colorable.NewColorableStdout(),
+	}
+}
+
+// NewStderrWriter returns ConsoleWriter object to write to stderr.
+// This generates win32 control sequences.
+func NewStderrWriter() ConsoleWriter {
+	return &WindowsWriter{
+		out: colorable.NewColorableStderr(),
 	}
 }


### PR DESCRIPTION
Add `NewStderrWriter` to support stderr output. To close https://github.com/c-bata/go-prompt/pull/101

Usage is like this:

```go
package main

import (
	"fmt"

	"github.com/c-bata/go-prompt"
)

func completer(in prompt.Document) []prompt.Suggest {
	s := []prompt.Suggest{
		{Text: "users", Description: "Store the username and age"},
		{Text: "articles", Description: "Store the article text posted by user"},
		{Text: "comments", Description: "Store the text commented to articles"},
		{Text: "groups", Description: "Combine users with specific rules"},
	}
	return prompt.FilterHasPrefix(s, in.GetWordBeforeCursor(), true)
}

func main() {
	in := prompt.Input(">>> ", completer,
		prompt.OptionWriter(prompt.NewStderrWriter()))  // <- set stderr writer
	fmt.Println("Your input: " + in)
}
```