### PR TITLE
support alt/meta-backspace to delete word.

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -106,6 +106,12 @@ var emacsKeyBindings = []KeyBind{
 			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursorWithSpace())))
 		},
 	},
+	{
+		Key: AltBackspace,
+		Fn: func(buf *Buffer) {
+			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursorWithSpace())))
+		},
+	},
 	// Clear the Screen, similar to the clear command
 	{
 		Key: ControlL,

--- a/input.go
+++ b/input.go
@@ -56,6 +56,7 @@ var asciiSequences = []*ASCIICode{
 	{Key: ControlCircumflex, ASCIICode: []byte{0x1e}},
 	{Key: ControlUnderscore, ASCIICode: []byte{0x1f}},
 	{Key: Backspace, ASCIICode: []byte{0x7f}},
+	{Key: AltBackspace, ASCIICode: []byte{0x1b, 0x7f}},
 
 	{Key: Up, ASCIICode: []byte{0x1b, 0x5b, 0x41}},
 	{Key: Down, ASCIICode: []byte{0x1b, 0x5b, 0x42}},

--- a/key.go
+++ b/key.go
@@ -72,6 +72,7 @@ const (
 	BackTab
 	Insert
 	Backspace
+	AltBackspace
 
 	// Aliases.
 	Tab


### PR DESCRIPTION
alt-backspace is a common "delete word" in bash (and mac os x).