### PR TITLE
Add SetColorFormat Sets

### DIFF
--- a/output.go
+++ b/output.go
@@ -158,4 +158,7 @@ type ConsoleWriter interface {
 
 	// SetColor sets text and background colors. and specify whether text is bold.
 	SetColor(fg, bg Color, bold bool)
+
+	// SetColorFormat sets text and background colors. and format
+	SetColorFormat(fg, bg Color, format DisplayAttribute)
 }

--- a/output_vt100.go
+++ b/output_vt100.go
@@ -243,6 +243,12 @@ func (w *VT100Writer) SetColor(fg, bg Color, bold bool) {
 	return
 }
 
+// SetColorFormat sets text and background colors. and format
+func (w *VT100Writer) SetColorFormat(fg, bg Color, format DisplayAttribute) {
+	w.SetDisplayAttributes(fg, bg, format)
+	return
+}
+
 // SetDisplayAttributes to set VT100 display attributes.
 func (w *VT100Writer) SetDisplayAttributes(fg, bg Color, attrs ...DisplayAttribute) {
 	w.WriteRaw([]byte{0x1b, '['}) // control sequence introducer


### PR DESCRIPTION
Hello
I'm using this library for auto-completion.

I notice that DisplayAttribute(ex DisplayBold, DisplayItalic...) only called  to SetColor.

So I added SetColorFormat Sets to use DisplayAttribute.

I've just started to use this library. So it may be possible to do that without adding a new set.
 In the case, I'll be happy if you kindly tell how to do that.