### PR TITLE
Fix http-prompt example (no exit)

### DIFF
--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -105,6 +105,9 @@ func executor(in string) {
 	var method, body string
 	blocks := strings.Split(in, " ")
 	switch blocks[0] {
+	case "exit":
+		fmt.Println("Bye!")
+		os.Exit(0)
 	case "cd":
 		if len(blocks) < 2 {
 			ctx.url.Path = "/"


### PR DESCRIPTION
Implement the exit function on the http-prompt example.