### PR TITLE
Down Arrow for first completion

### DIFF
--- a/option.go
+++ b/option.go
@@ -206,7 +206,7 @@ func OptionSwitchKeyBindMode(m KeyBindMode) Option {
 	}
 }
 
-// OptionSwitchKeyBindMode set a key bind mode.
+// OptionCompletionOnDown allows for Down arrow key to trigger completion.
 func OptionCompletionOnDown() Option {
 	return func(p *Prompt) error {
 		p.completionOnDown = true

--- a/option.go
+++ b/option.go
@@ -206,6 +206,14 @@ func OptionSwitchKeyBindMode(m KeyBindMode) Option {
 	}
 }
 
+// OptionSwitchKeyBindMode set a key bind mode.
+func OptionCompletionOnDown() Option {
+	return func(p *Prompt) error {
+		p.completionOnDown = true
+		return nil
+	}
+}
+
 // SwitchKeyBindMode to set a key bind mode.
 // Deprecated: Please use OptionSwitchKeyBindMode.
 var SwitchKeyBindMode = OptionSwitchKeyBindMode

--- a/prompt.go
+++ b/prompt.go
@@ -25,6 +25,7 @@ type Prompt struct {
 	keyBindings       []KeyBind
 	ASCIICodeBindings []ASCIICodeBind
 	keyBindMode       KeyBindMode
+	completionOnDown  bool
 }
 
 // Exec is the struct contains user input context.
@@ -126,7 +127,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		if !completing { // Don't use p.completion.Completing() because it takes double operation when switch to selected=-1.
 			if newBuf, changed := p.history.Newer(p.buf); changed {
 				p.buf = newBuf
-			} else {
+			} else if p.completionOnDown {
 				p.completion.Next()
 			}
 			return

--- a/prompt.go
+++ b/prompt.go
@@ -126,6 +126,8 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		if !completing { // Don't use p.completion.Completing() because it takes double operation when switch to selected=-1.
 			if newBuf, changed := p.history.Newer(p.buf); changed {
 				p.buf = newBuf
+			} else {
+				p.completion.Next()
 			}
 			return
 		}

--- a/prompt.go
+++ b/prompt.go
@@ -127,8 +127,6 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		if !completing { // Don't use p.completion.Completing() because it takes double operation when switch to selected=-1.
 			if newBuf, changed := p.history.Newer(p.buf); changed {
 				p.buf = newBuf
-			} else if p.completionOnDown {
-				p.completion.Next()
 			}
 			return
 		}
@@ -151,7 +149,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 func (p *Prompt) handleCompletionKeyBinding(key Key, completing bool) {
 	switch key {
 	case Down:
-		if completing {
+		if completing || p.completionOnDown {
 			p.completion.Next()
 		}
 	case Tab, ControlI:


### PR DESCRIPTION
go-prompt, when used with OptionShowCompletionAtStart, display the list of possible completion.

The users will (almost always) try and access those options through the down arrow (instead of tab)
They take time realizing that:

- tab must be used first
- then up and down arrows work as expected.

With the new option OptionCompletionOnDown, the down arrow key will trigger access to the first completion (since there is no "newer" history to read from the buffer)

That is more intuitive for users: they can start with the down arrow immediately and select the right completion from the displayed list of completion (again, because of OptionShowCompletionAtStart)

Without OptionCompletionOnDown, go-prompt behaves as it does today: no changes.