### PR TITLE
Support multi-line paste

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -256,10 +256,10 @@ func (p *Prompt) readBuffer(bufCh chan []byte, stopCh chan struct{}) {
 			if b, err := p.in.Read(); err == nil && !(len(b) == 1 && b[0] == 0) {
 				start := 0
 				for i, e := range b {
-					switch GetKey([] byte{e}) {
-					case Enter, ControlJ, ControlM: 
+					switch GetKey([]byte{e}) {
+					case Enter, ControlJ, ControlM:
 						bufCh <- b[start:i]
-						bufCh <- [] byte{e}
+						bufCh <- []byte{e}
 						start = i + 1
 					}
 				}

--- a/prompt.go
+++ b/prompt.go
@@ -254,7 +254,16 @@ func (p *Prompt) readBuffer(bufCh chan []byte, stopCh chan struct{}) {
 			return
 		default:
 			if b, err := p.in.Read(); err == nil && !(len(b) == 1 && b[0] == 0) {
-				bufCh <- b
+				start := 0
+				for i, e := range b {
+					switch GetKey([] byte{e}) {
+					case Enter, ControlJ, ControlM: 
+						bufCh <- b[start:i]
+						bufCh <- [] byte{e}
+						start = i + 1
+					}
+				}
+				bufCh <- b[start:]
 			}
 		}
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
When pasting (e. g. ⌘-v on Mac) multiline text to a go-prompt application, Prompt.readBuffer gets all the input as a whole, which makes Prompt.feed falls to the `NotDefined` case even if there's a `'/r'` in each line. As a result, the multiline input cannot be execute properly because it ruins the buffer area .

This commit fix the problem by sending newlines (if any) seperately.