### PR TITLE
Attach last key stroke to document

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -13,6 +13,7 @@ type Buffer struct {
 	cursorPosition  int
 	cacheDocument   *Document
 	preferredColumn int // Remember the original column for the next up/down movement.
+	lastKeyStroke   Key
 }
 
 // Text returns string of the current line.
@@ -30,6 +31,7 @@ func (b *Buffer) Document() (d *Document) {
 			cursorPosition: b.cursorPosition,
 		}
 	}
+	b.cacheDocument.lastKey = b.lastKeyStroke
 	return b.cacheDocument
 }
 

--- a/document.go
+++ b/document.go
@@ -16,6 +16,7 @@ type Document struct {
 	// So if Document is "日本(cursor)語", cursorPosition is 2.
 	// But DisplayedCursorPosition returns 4 because '日' and '本' are double width characters.
 	cursorPosition int
+	lastKey        Key
 }
 
 // NewDocument return the new empty document.
@@ -24,6 +25,11 @@ func NewDocument() *Document {
 		Text:           "",
 		cursorPosition: 0,
 	}
+}
+
+// LastKeyStroke return the last key pressed in this document.
+func (d *Document) LastKeyStroke() Key {
+	return d.lastKey
 }
 
 // DisplayCursorPosition returns the cursor position on rendered text on terminal emulators.

--- a/prompt.go
+++ b/prompt.go
@@ -98,7 +98,7 @@ func (p *Prompt) Run() {
 
 func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 	key := GetKey(b)
-
+	p.buf.lastKeyStroke = key
 	// completion
 	completing := p.completion.Completing()
 	p.handleCompletionKeyBinding(key, completing)


### PR DESCRIPTION
Hello, 
I am currently using go-prompt to build a cli tool, and I was wondering how to get the last key stroke in a Completer (using the Document).

Therefore, I created this PR which will attach the last key stroke to the buffer and update the document with each new feed.
The reason of doing this is to check for inputs (input.go) in each iteration of the completer. This for example enables users to exclude certain completions when pressing backspace. 

If there is a possibility to get the last key stroke in the current implementation, I would love to get some info.

Otherwise, I would be happy about any improvements to this PR. 