### PR TITLE
Fix runtime error: index out of range in GetSelectedSuggestion

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -48,6 +48,9 @@ func (c *CompletionManager) GetSelectedSuggestion() (s Suggest, ok bool) {
 		c.selected = -1
 		return Suggest{}, false
 	}
+	if len(c.tmp) == 0 || len(c.tmp) <= c.selected {
+	        return Suggest{}, false
+	}
 	return c.tmp[c.selected], true
 }
 


### PR DESCRIPTION
When I enter [tab] many times, will panic like below:
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/c-bata/go-prompt.(*CompletionManager).GetSelectedSuggestion(0xc0004320f0, 0xc000424c40, 0xc0004320f0, 0x17, 0x6f00000063, 0x6500000072)
	/root/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/completion.go:51 +0x13f
github.com/c-bata/go-prompt.(*Render).Render(0xc000430f70, 0xc000424c40, 0xc0004320f0)
	/root/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/render.go:209 +0x3dd
github.com/c-bata/go-prompt.(*Prompt).Run(0xc00044f700)
	/root/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/prompt.go:96 +0x6f9
github.com/shipengqi/hawk-eye/app/hectl/cmd.promptCommand.func1(0xc0001faf00, 0x1d61f80, 0x0, 0x0)
	/root/hawk-eye/app/hectl/cmd/prompt.go:38 +0x39f
github.com/spf13/cobra.(*Command).execute(0xc0001faf00, 0x1d61f80, 0x0, 0x0, 0xc0001faf00, 0x1d61f80)
	/root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001fac80, 0x0, 0x111c640, 0xc000096058)
	/root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/root/hawk-eye/app/hectl/main.go:7 +0x28
