### PR TITLE
ExitChecker: Exit go-prompt Run() for loop

### DIFF
--- a/option.go
+++ b/option.go
@@ -250,6 +250,13 @@ func OptionBreakLineCallback(fn func(*Document)) Option {
 	}
 }
 
+func OptionSetExitCheckerOnInput(fn Exitor) Option {
+	return func(p *Prompt) error {
+		p.exitor = fn
+		return nil
+	}
+}
+
 // New returns a Prompt with powerful auto-completion.
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	defaultWriter := NewStdoutWriter()

--- a/option.go
+++ b/option.go
@@ -251,9 +251,9 @@ func OptionBreakLineCallback(fn func(*Document)) Option {
 }
 
 // OptionSetExitCheckerOnInput set an exit function which checks if go-prompt exits its Run loop
-func OptionSetExitCheckerOnInput(fn Exitor) Option {
+func OptionSetExitCheckerOnInput(fn ExitChecker) Option {
 	return func(p *Prompt) error {
-		p.exitor = fn
+		p.exitChecker = fn
 		return nil
 	}
 }

--- a/option.go
+++ b/option.go
@@ -250,6 +250,7 @@ func OptionBreakLineCallback(fn func(*Document)) Option {
 	}
 }
 
+// OptionSetExitCheckerOnInput set an exit function which checks if go-prompt exits its Run loop
 func OptionSetExitCheckerOnInput(fn Exitor) Option {
 	return func(p *Prompt) error {
 		p.exitor = fn

--- a/prompt.go
+++ b/prompt.go
@@ -64,7 +64,6 @@ func (p *Prompt) Run() {
 	go p.handleSignals(exitCh, winSizeCh, stopHandleSignalCh)
 
 	for {
-		p.inNotTearedDown = true
 		select {
 		case b := <-bufCh:
 			if shouldExit, e := p.feed(b); shouldExit {
@@ -79,7 +78,6 @@ func (p *Prompt) Run() {
 
 				// Unset raw mode
 				// Reset to Blocking mode because returned EAGAIN when still set non-blocking mode.
-				p.inNotTearedDown = false
 				debug.AssertNoError(p.in.TearDown())
 				p.executor(e.input)
 
@@ -88,6 +86,7 @@ func (p *Prompt) Run() {
 				p.renderer.Render(p.buf, p.completion)
 
 				if p.exitor != nil && p.exitor(e.input) {
+					p.inNotTearedDown = false
 					return
 				}
 				// Set raw mode

--- a/prompt.go
+++ b/prompt.go
@@ -11,6 +11,10 @@ import (
 // Executor is called when user input something text.
 type Executor func(string)
 
+// Exitor is called after user input something text, to check if
+// prompt must stop and exit
+type Exitor func(string) bool
+
 // Completer should return the suggest item from Document.
 type Completer func(Document) []Suggest
 
@@ -26,6 +30,7 @@ type Prompt struct {
 	ASCIICodeBindings []ASCIICodeBind
 	keyBindMode       KeyBindMode
 	completionOnDown  bool
+	exitor            Exitor
 }
 
 // Exec is the struct contains user input context.
@@ -74,6 +79,11 @@ func (p *Prompt) Run() {
 				p.executor(e.input)
 
 				p.completion.Update(*p.buf.Document())
+
+				if p.exitor != nil && p.exitor(e.input) {
+					return
+				}
+
 				p.renderer.Render(p.buf, p.completion)
 
 				// Set raw mode

--- a/prompt.go
+++ b/prompt.go
@@ -11,10 +11,10 @@ import (
 // Executor is called when user input something text.
 type Executor func(string)
 
-// Exitor is called after user input to check if prompt must stop and exit go-prompt Run loop.
+// ExitChecker is called after user input to check if prompt must stop and exit go-prompt Run loop.
 // User input means: selecting/typing an entry, then <return>, and the executor is called.
-// Then, if said entry content matches the Exitor function criteria, exit go-prompt (not the overall Go program)
-type Exitor func(string) bool
+// Then, if said entry content matches the ExitChecker function criteria, exit go-prompt (not the overall Go program)
+type ExitChecker func(string) bool
 
 // Completer should return the suggest item from Document.
 type Completer func(Document) []Suggest
@@ -31,7 +31,7 @@ type Prompt struct {
 	ASCIICodeBindings []ASCIICodeBind
 	keyBindMode       KeyBindMode
 	completionOnDown  bool
-	exitor            Exitor
+	exitChecker       ExitChecker
 	inNotTearedDown   bool
 }
 
@@ -85,7 +85,7 @@ func (p *Prompt) Run() {
 
 				p.renderer.Render(p.buf, p.completion)
 
-				if p.exitor != nil && p.exitor(e.input) {
+				if p.exitChecker != nil && p.exitChecker(e.input) {
 					p.inNotTearedDown = false
 					return
 				}

--- a/prompt.go
+++ b/prompt.go
@@ -32,7 +32,7 @@ type Prompt struct {
 	keyBindMode       KeyBindMode
 	completionOnDown  bool
 	exitChecker       ExitChecker
-	inNotTearedDown   bool
+	skipTearDown      bool
 }
 
 // Exec is the struct contains user input context.
@@ -42,7 +42,7 @@ type Exec struct {
 
 // Run starts prompt.
 func (p *Prompt) Run() {
-	p.inNotTearedDown = true
+	p.skipTearDown = false
 	defer debug.Teardown()
 	debug.Log("start prompt")
 	p.setUp()
@@ -86,7 +86,7 @@ func (p *Prompt) Run() {
 				p.renderer.Render(p.buf, p.completion)
 
 				if p.exitChecker != nil && p.exitChecker(e.input) {
-					p.inNotTearedDown = false
+					p.skipTearDown = true
 					return
 				}
 				// Set raw mode
@@ -282,7 +282,7 @@ func (p *Prompt) setUp() {
 }
 
 func (p *Prompt) tearDown() {
-	if p.inNotTearedDown {
+	if !p.skipTearDown {
 		debug.AssertNoError(p.in.TearDown())
 	}
 	p.renderer.TearDown()


### PR DESCRIPTION
This allows go-prompt for loop in `Run()` to exit once a selection has been done.

Instead of just `os.Exit()` (which can be registered, but stops everything), you can add a simple exit function which will compare what has been selected in the prompt with a value.

If that matches, that exit functions returns true, go-prompt returns from `Run()`, and the rest of the Go program continues.

That allows to call go-prompt, select something, and then go on with the rest of the program.