### PR TITLE
Trigger ExitChecker on pressed keys

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -210,7 +210,7 @@ func (p *Prompt) handleKeyBinding(key Key) bool {
 			kb.Fn(p.buf)
 		}
 	}
-	if p.exitor != nil && p.exitor(p.buf.Text()) {
+	if p.exitChecker != nil && p.exitChecker(p.buf.Text()) {
 		shouldExit = true
 	}
 	return shouldExit

--- a/prompt.go
+++ b/prompt.go
@@ -155,7 +155,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		p.buf.InsertText(string(b), false, true)
 	}
 
-	p.handleKeyBinding(key)
+	shouldExit = p.handleKeyBinding(key)
 	return
 }
 
@@ -185,7 +185,8 @@ func (p *Prompt) handleCompletionKeyBinding(key Key, completing bool) {
 	}
 }
 
-func (p *Prompt) handleKeyBinding(key Key) {
+func (p *Prompt) handleKeyBinding(key Key) bool {
+	shouldExit := false
 	for i := range commonKeyBindings {
 		kb := commonKeyBindings[i]
 		if kb.Key == key {
@@ -209,6 +210,10 @@ func (p *Prompt) handleKeyBinding(key Key) {
 			kb.Fn(p.buf)
 		}
 	}
+	if p.exitor != nil && p.exitor(p.buf.Text()) {
+		shouldExit = true
+	}
+	return shouldExit
 }
 
 func (p *Prompt) handleASCIICodeBinding(b []byte) bool {


### PR DESCRIPTION
#161  allows to exit go-prompt (not the all Go program like an `os.Exit()`, but just go-prompt) when the user type `<return>` and select an entry matching a criteria.

This PR adds the same exit-go-prompt option to each _key_ typed.

The general goal is to allow for an early exit as soon as a character (or sequence of characters) has been typed, without having to type `<enter>`.

Example use-case: a go-prompt with three choices 'yes', 'no', 'cancel'.

The following example would allow a user to select yes or no, just by typing 'y' or 'n' (no need to type `<return>`), or 'cancel' by typing ESC.
That would _not_ call `os.Exit`, just exit the go-prompt `Run()` loop, without executor.

````go
type choice struct {
	isCancel bool
	isYes    bool
}

func (c *choice) cancel(_ *prompt.Buffer) {
	c.isCancel = true
}

func (c *choice) checkIfExit(in string) bool {
	c.isYes = (in == "y")
	return in == "y" || in == "n" || c.isCancel
}

func main() {
	c := &choice{}
	exitOnEscape := prompt.KeyBind{
		Key: prompt.Escape,
		Fn:  c.cancel,
	}
	p := prompt.New(
		executor,
		completer,
		prompt.OptionPrefix(">>> "),
		prompt.OptionSetExitCheckerOnInput(c.checkIfExit),
		prompt.OptionCompletionOnDown(),
		prompt.OptionAddKeyBind(exitOnEscape),
	)
	p.Run()
	fmt.Println("All done")
	fmt.Printf("Choice '%t', cancelled: '%t'\n", c.isYes, c.isCancel)
}
````

