### PR TITLE
Don't test render on Windows

### DIFF
--- a/render_test.go
+++ b/render_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package prompt
 
 import (


### PR DESCRIPTION
`render_test.go` uses `PosixWriter`, which is defined in `output_posix.go`, a file marked with `+build !windows`

That means any test build would always fail on Windows, as shown in https://travis-ci.org/c-bata/go-prompt/builds/652864849, more precisely https://travis-ci.org/c-bata/go-prompt/jobs/652864854

    .\render_test.go:74:9: undefined: PosixWriter

One solution (this PR) is simply to exclude `render_test.go` from build on Windows.

Another option might be to split it in two, if some part of that test file still warrant a build on Windows (while the part involving `PosixWriter` clearly does not)