### PR TITLE
Fix golangci-lint -fast warnings

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -71,6 +71,7 @@ func (b *Buffer) setText(v string) {
 	b.workingLines[b.workingIndex] = v
 
 	if o != v {
+		dummyExecutor("")
 		// Text is changed.
 		// TODO: Call callback function triggered by text changed. And also history search text should reset.
 		// https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/prompt_toolkit/buffer.py#L380-L384
@@ -86,6 +87,7 @@ func (b *Buffer) setCursorPosition(p int) {
 		b.cursorPosition = 0
 	}
 	if p != o {
+		dummyExecutor("")
 		// Cursor position is changed.
 		// TODO: Call a onCursorPositionChanged function.
 	}
@@ -101,14 +103,12 @@ func (b *Buffer) setDocument(d *Document) {
 func (b *Buffer) CursorLeft(count int) {
 	l := b.Document().GetCursorLeftPosition(count)
 	b.cursorPosition += l
-	return
 }
 
 // CursorRight move to right on the current line.
 func (b *Buffer) CursorRight(count int) {
 	l := b.Document().GetCursorRightPosition(count)
 	b.cursorPosition += l
-	return
 }
 
 // CursorUp move cursor to the previous line.

--- a/completion.go
+++ b/completion.go
@@ -61,13 +61,11 @@ func (c *CompletionManager) Reset() {
 	c.selected = -1
 	c.verticalScroll = 0
 	c.Update(*NewDocument())
-	return
 }
 
 // Update to update the suggestions.
 func (c *CompletionManager) Update(in Document) {
 	c.tmp = c.completer(in)
-	return
 }
 
 // Previous to select the previous suggestion item.
@@ -77,7 +75,6 @@ func (c *CompletionManager) Previous() {
 	}
 	c.selected--
 	c.update()
-	return
 }
 
 // Next to select the next suggestion item.
@@ -87,7 +84,6 @@ func (c *CompletionManager) Next() {
 	}
 	c.selected++
 	c.update()
-	return
 }
 
 // Completing returns whether the CompletionManager selects something one.

--- a/filter.go
+++ b/filter.go
@@ -30,10 +30,10 @@ func FilterFuzzy(completions []Suggest, sub string, ignoreCase bool) []Suggest {
 
 func fuzzyMatch(s, sub string) bool {
 	sChars := []rune(s)
-	subChars := []rune(sub)
 	sIdx := 0
 
-	for _, c := range subChars {
+	// https://staticcheck.io/docs/checks#S1029
+	for _, c := range sub {
 		found := false
 		for ; sIdx < len(sChars); sIdx++ {
 			if sChars[sIdx] == c {

--- a/output_vt100.go
+++ b/output_vt100.go
@@ -13,25 +13,21 @@ type VT100Writer struct {
 // WriteRaw to write raw byte array
 func (w *VT100Writer) WriteRaw(data []byte) {
 	w.buffer = append(w.buffer, data...)
-	return
 }
 
 // Write to write safety byte array by removing control sequences.
 func (w *VT100Writer) Write(data []byte) {
 	w.WriteRaw(bytes.Replace(data, []byte{0x1b}, []byte{'?'}, -1))
-	return
 }
 
 // WriteRawStr to write raw string
 func (w *VT100Writer) WriteRawStr(data string) {
 	w.WriteRaw([]byte(data))
-	return
 }
 
 // WriteStr to write safety string by removing control sequences.
 func (w *VT100Writer) WriteStr(data string) {
 	w.Write([]byte(data))
-	return
 }
 
 /* Erase */
@@ -39,37 +35,31 @@ func (w *VT100Writer) WriteStr(data string) {
 // EraseScreen erases the screen with the background colour and moves the cursor to home.
 func (w *VT100Writer) EraseScreen() {
 	w.WriteRaw([]byte{0x1b, '[', '2', 'J'})
-	return
 }
 
 // EraseUp erases the screen from the current line up to the top of the screen.
 func (w *VT100Writer) EraseUp() {
 	w.WriteRaw([]byte{0x1b, '[', '1', 'J'})
-	return
 }
 
 // EraseDown erases the screen from the current line down to the bottom of the screen.
 func (w *VT100Writer) EraseDown() {
 	w.WriteRaw([]byte{0x1b, '[', 'J'})
-	return
 }
 
 // EraseStartOfLine erases from the current cursor position to the start of the current line.
 func (w *VT100Writer) EraseStartOfLine() {
 	w.WriteRaw([]byte{0x1b, '[', '1', 'K'})
-	return
 }
 
 // EraseEndOfLine erases from the current cursor position to the end of the current line.
 func (w *VT100Writer) EraseEndOfLine() {
 	w.WriteRaw([]byte{0x1b, '[', 'K'})
-	return
 }
 
 // EraseLine erases the entire current line.
 func (w *VT100Writer) EraseLine() {
 	w.WriteRaw([]byte{0x1b, '[', '2', 'K'})
-	return
 }
 
 /* Cursor */
@@ -82,7 +72,6 @@ func (w *VT100Writer) ShowCursor() {
 // HideCursor hides cursor.
 func (w *VT100Writer) HideCursor() {
 	w.WriteRaw([]byte{0x1b, '[', '?', '2', '5', 'l'})
-	return
 }
 
 // CursorGoTo sets the cursor position where subsequent text will begin.
@@ -99,7 +88,6 @@ func (w *VT100Writer) CursorGoTo(row, col int) {
 	w.WriteRaw([]byte{';'})
 	w.WriteRaw([]byte(c))
 	w.WriteRaw([]byte{'H'})
-	return
 }
 
 // CursorUp moves the cursor up by 'n' rows; the default count is 1.
@@ -114,7 +102,6 @@ func (w *VT100Writer) CursorUp(n int) {
 	w.WriteRaw([]byte{0x1b, '['})
 	w.WriteRaw([]byte(s))
 	w.WriteRaw([]byte{'A'})
-	return
 }
 
 // CursorDown moves the cursor down by 'n' rows; the default count is 1.
@@ -129,7 +116,6 @@ func (w *VT100Writer) CursorDown(n int) {
 	w.WriteRaw([]byte{0x1b, '['})
 	w.WriteRaw([]byte(s))
 	w.WriteRaw([]byte{'B'})
-	return
 }
 
 // CursorForward moves the cursor forward by 'n' columns; the default count is 1.
@@ -144,7 +130,6 @@ func (w *VT100Writer) CursorForward(n int) {
 	w.WriteRaw([]byte{0x1b, '['})
 	w.WriteRaw([]byte(s))
 	w.WriteRaw([]byte{'C'})
-	return
 }
 
 // CursorBackward moves the cursor backward by 'n' columns; the default count is 1.
@@ -159,26 +144,22 @@ func (w *VT100Writer) CursorBackward(n int) {
 	w.WriteRaw([]byte{0x1b, '['})
 	w.WriteRaw([]byte(s))
 	w.WriteRaw([]byte{'D'})
-	return
 }
 
 // AskForCPR asks for a cursor position report (CPR).
 func (w *VT100Writer) AskForCPR() {
 	// CPR: Cursor Position Request.
 	w.WriteRaw([]byte{0x1b, '[', '6', 'n'})
-	return
 }
 
 // SaveCursor saves current cursor position.
 func (w *VT100Writer) SaveCursor() {
 	w.WriteRaw([]byte{0x1b, '[', 's'})
-	return
 }
 
 // UnSaveCursor restores cursor position after a Save Cursor.
 func (w *VT100Writer) UnSaveCursor() {
 	w.WriteRaw([]byte{0x1b, '[', 'u'})
-	return
 }
 
 /* Scrolling */
@@ -186,13 +167,11 @@ func (w *VT100Writer) UnSaveCursor() {
 // ScrollDown scrolls display down one line.
 func (w *VT100Writer) ScrollDown() {
 	w.WriteRaw([]byte{0x1b, 'D'})
-	return
 }
 
 // ScrollUp scroll display up one line.
 func (w *VT100Writer) ScrollUp() {
 	w.WriteRaw([]byte{0x1b, 'M'})
-	return
 }
 
 /* Title */
@@ -220,13 +199,11 @@ func (w *VT100Writer) SetTitle(title string) {
 	w.WriteRaw([]byte{0x1b, ']', '2', ';'})
 	w.WriteRaw(titleBytes)
 	w.WriteRaw([]byte{0x07})
-	return
 }
 
 // ClearTitle clears a title of terminal window.
 func (w *VT100Writer) ClearTitle() {
 	w.WriteRaw([]byte{0x1b, ']', '2', ';', 0x07})
-	return
 }
 
 /* Font */
@@ -240,7 +217,6 @@ func (w *VT100Writer) SetColor(fg, bg Color, bold bool) {
 		// Details are https://github.com/c-bata/go-prompt/pull/85
 		w.SetDisplayAttributes(fg, bg, DisplayReset)
 	}
-	return
 }
 
 // SetDisplayAttributes to set VT100 display attributes.
@@ -269,7 +245,6 @@ func (w *VT100Writer) SetDisplayAttributes(fg, bg Color, attrs ...DisplayAttribu
 		b = backgroundANSIColors[DefaultColor]
 	}
 	w.WriteRaw(b)
-	return
 }
 
 var displayAttributeParameters = map[DisplayAttribute][]byte{

--- a/output_windows.go
+++ b/output_windows.go
@@ -28,7 +28,7 @@ func (w *WindowsWriter) Flush() error {
 var _ ConsoleWriter = &WindowsWriter{}
 
 var (
-	// Deprecated: Please use NewStdoutWriter
+	// NewStandardOutputWriter is Deprecated: Please use NewStdoutWriter
 	NewStandardOutputWriter = NewStdoutWriter
 )
 

--- a/prompt.go
+++ b/prompt.go
@@ -221,7 +221,7 @@ func (p *Prompt) handleKeyBinding(key Key) bool {
 func (p *Prompt) handleASCIICodeBinding(b []byte) bool {
 	checked := false
 	for _, kb := range p.ASCIICodeBindings {
-		if bytes.Compare(kb.ASCIICode, b) == 0 {
+		if bytes.Equal(kb.ASCIICode, b) {
 			kb.Fn(p.buf)
 			checked = true
 		}

--- a/render.go
+++ b/render.go
@@ -75,14 +75,12 @@ func (r *Render) prepareArea(lines int) {
 	for i := 0; i < lines; i++ {
 		r.out.ScrollUp()
 	}
-	return
 }
 
 // UpdateWinSize called when window size is changed.
 func (r *Render) UpdateWinSize(ws *WinSize) {
 	r.row = ws.Row
 	r.col = ws.Col
-	return
 }
 
 func (r *Render) renderWindowTooSmall() {
@@ -90,7 +88,6 @@ func (r *Render) renderWindowTooSmall() {
 	r.out.EraseScreen()
 	r.out.SetColor(DarkRed, White, false)
 	r.out.WriteStr("Your console window is too small...")
-	return
 }
 
 func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
@@ -167,7 +164,6 @@ func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
 
 	r.out.CursorUp(windowHeight)
 	r.out.SetColor(DefaultColor, DefaultColor, false)
-	return
 }
 
 // Render renders to the console.

--- a/shortcut.go
+++ b/shortcut.go
@@ -1,6 +1,6 @@
 package prompt
 
-func dummyExecutor(in string) { return }
+func dummyExecutor(in string) {}
 
 // Input get the input data from the user and return it.
 func Input(prefix string, completer Completer, opts ...Option) string {


### PR DESCRIPTION
The next series of PRs will aim to fix as many linter warnings as possible.

This one fixes:

    golangci-lint.exe run --fast --exclude-use-default=false

This is the default linter integration with IDE like VSCode (https://github.com/golangci/golangci-lint#editor-integration)

Merging that PR means that, by default, the project compiles without warning.