### PR TITLE
Fix gosec warnings

### DIFF
--- a/input_windows.go
+++ b/input_windows.go
@@ -40,6 +40,7 @@ func (p *WindowsParser) TearDown() error {
 // Read returns byte array.
 func (p *WindowsParser) Read() ([]byte, error) {
 	var ev uint32
+	// #nosec G103
 	r0, _, err := procGetNumberOfConsoleInputEvents.Call(p.tty.Input().Fd(), uintptr(unsafe.Pointer(&ev)))
 	if r0 == 0 {
 		return nil, err

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -1,9 +1,13 @@
 package bisect_test
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"testing"
+
+	crypto_rand "crypto/rand"
+	math_rand "math/rand"
 
 	"github.com/c-bata/go-prompt/internal/bisect"
 )
@@ -34,7 +38,14 @@ func TestBisectRight(t *testing.T) {
 }
 
 func BenchmarkRight(b *testing.B) {
-	rand.Seed(0)
+	// https://stackoverflow.com/a/54491783/6309
+	var bb [8]byte
+	_, err := crypto_rand.Read(bb[:])
+	if err != nil {
+		panic("cannot seed math/rand package with cryptographically secure random number generator")
+	}
+	// Avoid G404: Use of weak random number generator (math/rand instead of crypto/rand)
+	math_rand.Seed(int64(binary.LittleEndian.Uint64(bb[:])))
 
 	for _, l := range []int{10, 1e2, 1e3, 1e4} {
 		x := rand.Perm(l)

--- a/internal/debug/log.go
+++ b/internal/debug/log.go
@@ -19,7 +19,8 @@ var (
 func init() {
 	if e := os.Getenv(envEnableLog); e == "true" || e == "1" {
 		var err error
-		logfile, err = os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+		// Avoid G302: Expect file permissions to be 0600 or less
+		logfile, err = os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		if err == nil {
 			logger = log.New(logfile, "", log.Llongfile)
 			return


### PR DESCRIPTION
This patch addresses warnings emitted by https://github.com/securego/gosec, the "Golang Security Checker".
