### PR TITLE
Check for zero in toPos

### DIFF
--- a/render.go
+++ b/render.go
@@ -266,6 +266,9 @@ func (r *Render) move(from, to int) int {
 // toPos returns the relative position from the beginning of the string.
 func (r *Render) toPos(cursor int) (x, y int) {
 	col := int(r.col)
+	if col == 0 {
+		return 0, 0
+	}
 	return cursor % col, cursor / col
 }
 


### PR DESCRIPTION
I encountered a crash in `render.go:toPos` when using `go-prompt` in combination with `goexpect`.  
Just adding this zero check fixes it, although I did not investigate how it gets there.  
  
<details>
<summary>Stacktrace</summary>
<pre>
panic(0xbe8d40, 0x156f4d0)  
	.go/src/runtime/panic.go:967 +0x15d  
github.com/c-bata/go-prompt.(*Render).toPos(...)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/render.go:268  
github.com/c-bata/go-prompt.(*Render).move(0xc0005a61a0, 0x42, 0x0, 0x2)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/render.go:257 +0xcc  
github.com/c-bata/go-prompt.(*Render).clear(0xc0005a61a0, 0x42)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/render.go:244 +0x3e  
github.com/c-bata/go-prompt.(*Render).BreakLine(0xc0005a61a0, 0xc0004a6cc0)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/render.go:231 +0x209  
github.com/c-bata/go-prompt.(*Prompt).feed(0xc000598580, 0xc000777c00, 0x1, 0x400, 0x1, 0x0)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/prompt.go:120 +0x274  
github.com/c-bata/go-prompt.(*Prompt).Run(0xc000598580)  
	go/pkg/mod/github.com/c-bata/go-prompt@v0.2.3/prompt.go:72 +0x579  
</pre>
</details>  
  
If you want I can also write a Bug report, but I thought it is quicker like this.