### PR TITLE
termio: Set character width to 8 bits

### DIFF
--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -20,7 +20,9 @@ func SetRaw(fd int) error {
 		syscall.ICRNL | syscall.IXON
 	n.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.IEXTEN | syscall.ISIG | syscall.ECHONL
 	n.Cflag &^= syscall.CSIZE | syscall.PARENB
+	n.Cflag |= syscall.CS8 // Set to 8-bit wide.  Typical value for displaying characters.
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
+
 	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*syscall.Termios)(&n))
 }


### PR DESCRIPTION
When setting terminal mode, the character size is getting cleared and
defaults to CS5 which causes the display to be garbled.  Since the
purpose of this libaray is to mainly output readable characters, CS8 is
a better value.

This can be easily seen when launching go-prompt over serial connection.

Bug: #179
Change-Id: I4c9d13fad699e09aa9f4f665b252cebdd63614a7