### PR TITLE
Update pkg/term module to latest and use unix.Termios

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ require (
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-runewidth v0.0.3
 	github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a
-	github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917
-	golang.org/x/sys v0.0.0-20180620133508-ad87a3a340fa
+	github.com/pkg/term v1.0.0
+	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299
 )

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,9 @@ github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a h1:8TGB3DFRNl06DB1Q6z
 github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917 h1:BinR73QvQveJdQ8uYZK/8MOjLADpZbI2qs/2+5rnhzQ=
 github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pkg/term v1.0.0 h1:raTSNJjic7X4n89hhPyLOsgRYczmr3MyezRierWCTa8=
+github.com/pkg/term v1.0.0/go.mod h1:6rk0zrj6TXf8MR5fdVFsZMeGM2lxe3tUFLNBRlwX+dk=
 golang.org/x/sys v0.0.0-20180620133508-ad87a3a340fa h1:MUO6aP6ViFfqImh/3zU3O6QX3W2hFRzkkuCIQuUCOsM=
 golang.org/x/sys v0.0.0-20180620133508-ad87a3a340fa/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 // SetRaw put terminal into a raw mode
@@ -24,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*syscall.Termios)(&n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -4,18 +4,18 @@ package term
 
 import (
 	"sync"
-	"syscall"
 
 	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 var (
-	saveTermios     syscall.Termios
+	saveTermios     unix.Termios
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (syscall.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd


### PR DESCRIPTION
Updating `pkg/term` is necessary to fix #190 

For more background, latest version of `pkg/term` has a change in argument type of function `termios.Tcsetattr`. See https://github.com/pkg/term/pull/51 for more details.

Anyone using `go prompt` with explicit dependency of `pkg/term` to latest would encounter with issue #190 

