### PR TITLE
Update input_posix.go

### DIFF
--- a/input_posix.go
+++ b/input_posix.go
@@ -47,6 +47,14 @@ func (t *PosixParser) Read() ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	if len(buf[:n]) >= 6 {
+		if buf[0] == buf[1] {
+			return buf[:1], nil
+		}
+		if buf[0] == buf[3] && buf[1] == buf[4] && buf[2] == buf[5] {
+			return buf[:3], nil
+		}
+	}
 	return buf[:n], nil
 }
 


### PR DESCRIPTION
In Linux, the Syscall(SYS_READ, uintptr(fd), uintptr(_p0), uintptr(len(p))) method may read characters entered on the keyboard multiple times at a time. In this case, the GetKey(b) method fails to match the key, causing the current command to insert redundant error characters. Therefore, the character read in this case is re-cut and only the first character is used.
