### PR TITLE
Fix wrong termios save code

### DIFF
--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -25,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -10,16 +10,18 @@ import (
 )
 
 var (
-	saveTermios     *unix.Termios
+	saveTermios     unix.Termios
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (*unix.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
-		saveTermios, err = termios.Tcgetattr(uintptr(fd))
+		var saveTermiosPtr *unix.Termios
+		saveTermiosPtr, err = termios.Tcgetattr(uintptr(fd))
+		saveTermios = *saveTermiosPtr
 	})
 	return saveTermios, err
 }
@@ -30,5 +32,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
 }


### PR DESCRIPTION
This bug is introduced by 20e0658bedf03de0604a1a4bf9c212b7a1e26970.
Saving a *unix.Termios and then modifying it in SetRaw() makes the
saved state useless.

By restoring saveTermios type from *unix.Termios to unix.Termios,
SetRaw() no longer influences the saved termios.

This should fix #228 and #233 .

Signed-off-by: Xiami <i@f2light.com>