### PR TITLE
Fix slice out of range when using insert text with overwrite option

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -47,7 +47,10 @@ func (b *Buffer) InsertText(v string, overwrite bool, moveCursor bool) {
 	oc := b.cursorPosition
 
 	if overwrite {
-		overwritten := string(or[oc : oc+len(v)])
+		overwritten := string(or[oc:])
+		if len(overwritten) >= oc+len(v) {
+			overwritten = string(or[oc : oc+len(v)])			
+		}
 		if strings.Contains(overwritten, "\n") {
 			i := strings.IndexAny(overwritten, "\n")
 			overwritten = overwritten[:i]

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -28,6 +28,33 @@ func TestBuffer_InsertText(t *testing.T) {
 	}
 }
 
+func TestBuffer_InsertText_Overwrite(t *testing.T) {
+	b := NewBuffer()
+	b.InsertText("ABC", false, true)
+
+	if b.Text() != "ABC" {
+		t.Errorf("Text should be %#v, got %#v", "ABC", b.Text())
+	}
+
+	if b.cursorPosition != len("ABC") {
+		t.Errorf("cursorPosition should be %#v, got %#v", len("ABC"), b.cursorPosition)
+	}
+
+	b.CursorLeft(1)
+	b.InsertText("DEF", true, true)
+
+	if b.Text() != "ABDEF" {
+		t.Errorf("Text should be %#v, got %#v", "ABDEF", b.Text())
+	}
+
+	b.CursorLeft(100)
+	b.InsertText("GHI", true, true)
+
+	if b.Text() != "GHIEF" {
+		t.Errorf("Text should be %#v, got %#v", "GHIEF", b.Text())
+	}
+}
+
 func TestBuffer_CursorMovement(t *testing.T) {
 	b := NewBuffer()
 	b.InsertText("some_text", false, true)

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -41,6 +41,7 @@ func TestBuffer_InsertText_Overwrite(t *testing.T) {
 	}
 
 	b.CursorLeft(1)
+	// Replace C with DEF in ABC
 	b.InsertText("DEF", true, true)
 
 	if b.Text() != "ABDEF" {
@@ -48,10 +49,28 @@ func TestBuffer_InsertText_Overwrite(t *testing.T) {
 	}
 
 	b.CursorLeft(100)
+	// Replace ABD with GHI in ABDEF
 	b.InsertText("GHI", true, true)
 
 	if b.Text() != "GHIEF" {
 		t.Errorf("Text should be %#v, got %#v", "GHIEF", b.Text())
+	}
+
+	b.CursorLeft(100)
+	// Replace GHI with J\nK in GHIEF
+	b.InsertText("J\nK", true, true)
+
+	if b.Text() != "J\nKEF" {
+		t.Errorf("Text should be %#v, got %#v", "J\nKEF", b.Text())
+	}
+
+	b.CursorUp(100)
+	b.CursorLeft(100)
+	// Replace J with LMN in J\nKEF test end of line
+	b.InsertText("LMN", true, true)
+
+	if b.Text() != "LMN\nKEF" {
+		t.Errorf("Text should be %#v, got %#v", "LMN\nKEF", b.Text())
 	}
 }
 


### PR DESCRIPTION
When you use InsertText with overwrite option, the length of the current text is not being checked and it causes panic if the current text's length is smaller than new text's length.  

Fixes #110 