### PR TITLE
Fix broken spacing for each row of completion area

### DIFF
--- a/render.go
+++ b/render.go
@@ -57,6 +57,7 @@ func (r *Render) getCurrentPrefix() string {
 
 func (r *Render) renderPrefix() {
 	r.out.SetColor(r.prefixTextColor, r.prefixBGColor, false)
+	r.out.WriteStr("\r")
 	r.out.WriteStr(r.getCurrentPrefix())
 	r.out.SetColor(DefaultColor, DefaultColor, false)
 }

--- a/render.go
+++ b/render.go
@@ -130,9 +130,12 @@ func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
 	}
 
 	selected := completions.selected - completions.verticalScroll
+	cursorColumnSpacing := cursor
+
 	r.out.SetColor(White, Cyan, false)
 	for i := 0; i < windowHeight; i++ {
-		r.out.CursorDown(1)
+		alignNextLine(r, cursorColumnSpacing)
+
 		if i == selected {
 			r.out.SetColor(r.selectedSuggestionTextColor, r.selectedSuggestionBGColor, true)
 		} else {
@@ -285,4 +288,10 @@ func clamp(high, low, x float64) float64 {
 	default:
 		return x
 	}
+}
+
+func alignNextLine(r *Render, col int) {
+	r.out.CursorDown(1)
+	r.out.WriteStr("\r")
+	r.out.CursorForward(col)
 }


### PR DESCRIPTION
We tried to use `Emoji`, but we found that **each row in the completion area was pushed back** as shown in the following issue.

Related issue: https://github.com/c-bata/go-prompt/issues/209

```bash
# Error case
md > 
           🎨    Store the username and age             
                ⚡️  Store the article text posted by user  
                   🔥    Store the text commented to articles   
                        🐛    Store the text commented to articles   
                             ✨    Store the text commented to articles   
                                 📝    Store the text commented to articles   

# Solved case
md > 🚧
      🎉    Store the text commented to articles   
      ✅    Store the text commented to articles   
      🔒    Store the text commented to articles   
      🔖    Store the text commented to articles   
      🚨    Store the text commented to articles   
      🚧    Store the text commented to articles   

```

Therefore, I applied `carriage return` to **specify the initial cursor of all rows** at the `column interval of the initial cursor`.

In addition, we applied `carriage return` before moving `the prefix` to `the current cursor column`, so that `the prefix` does not look redundant.

```bash
# init state
abcdefghi > 
             🎉    Store the text commented to articles   
             ✅    Store the text commented to articles   
             🔒    Store the text commented to articles   
             🔖    Store the text commented to articles   
             🚨    Store the text commented to articles   
             🚧    Store the text commented to articles   

# error case
aabcdefghi > 🌱        // The 'a' of old prefix  remains.
             🥅    Store the text commented to articles   
             🚩    Store the text commented to articles   
             🌱    Store the text commented to articles   
             🏷     Store the text commented to articles   
             🔍    Store the text commented to articles   
             ⚗     Store the text commented to articles   

```