### PR TITLE
Bug fix: Ensure original terminal state is not overwritten

### DIFF
--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -25,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -15,13 +15,13 @@ var (
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (*unix.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
 		saveTermios, err = termios.Tcgetattr(uintptr(fd))
 	})
-	return saveTermios, err
+	return *saveTermios, err
 }
 
 // Restore terminal's mode.
@@ -30,5 +30,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
 }


### PR DESCRIPTION
This should fix #233 

It appears that returning a pointer from `getOriginalTermios` was causing subsequent calls to `termios.Tcsetattr` to overwrite the original terminal state and breaking control character sequences when the program exited. Returning a copy of `saveTermios` seems to fix this problem.