### PR TITLE
Fix file descriptor leak

### DIFF
--- a/input_posix.go
+++ b/input_posix.go
@@ -34,6 +34,9 @@ func (t *PosixParser) TearDown() error {
 	if err := syscall.SetNonblock(t.fd, false); err != nil {
 		return err
 	}
+	if err := syscall.Close(t.fd); err != nil {
+		return err
+	}
 	if err := term.Restore(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes file descriptor leak as described in #253 

Reproduced by modifying `_example/simple-echo/main.go`, looping the body of the main function in order to observe multiple calls to `prompt.Input()`. "Exit" added for convenience:

```diff
diff --git a/_example/simple-echo/main.go b/_example/simple-echo/main.go
index 12b1bb4..b02199f 100644
--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -12,17 +12,23 @@ func completer(in prompt.Document) []prompt.Suggest {
 		{Text: "articles", Description: "Store the article text posted by user"},
 		{Text: "comments", Description: "Store the text commented to articles"},
 		{Text: "groups", Description: "Combine users with specific rules"},
+		{Text: "exit", Description: "Stop the loop"},
 	}
 	return prompt.FilterHasPrefix(s, in.GetWordBeforeCursor(), true)
 }
 
 func main() {
-	in := prompt.Input(">>> ", completer,
-		prompt.OptionTitle("sql-prompt"),
-		prompt.OptionHistory([]string{"SELECT * FROM users;"}),
-		prompt.OptionPrefixTextColor(prompt.Yellow),
-		prompt.OptionPreviewSuggestionTextColor(prompt.Blue),
-		prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
-		prompt.OptionSuggestionBGColor(prompt.DarkGray))
-	fmt.Println("Your input: " + in)
+	for {
+		in := prompt.Input(">>> ", completer,
+			prompt.OptionTitle("sql-prompt"),
+			prompt.OptionHistory([]string{"SELECT * FROM users;"}),
+			prompt.OptionPrefixTextColor(prompt.Yellow),
+			prompt.OptionPreviewSuggestionTextColor(prompt.Blue),
+			prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
+			prompt.OptionSuggestionBGColor(prompt.DarkGray))
+		if in == "exit" {
+			break
+		}
+		fmt.Println("Your input: " + in)
+	}
 }
```

Each call to Input will leak another file descriptor, seen with `lsof -p <GO PID> | grep 'dev\/tty' | wc -l`:

Here you can see the count of /dev/tty file descriptors increasing:
<img width="1049" alt="Screen Shot 2022-04-28 at 21 53 46" src="https://user-images.githubusercontent.com/32749186/165887030-043a3ef4-b58d-4104-8ca5-90ca0787fb93.png">


Calling `syscall.Close(t.fd)` prevents this leak. After this fix the count of file descriptors is constant:
<img width="1049" alt="Screen Shot 2022-04-28 at 21 56 20" src="https://user-images.githubusercontent.com/32749186/165887212-39d4fae5-d661-44b1-a451-53a04c675a48.png">

