### PR TITLE
support meta-{backspace,left,right} key.

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -94,6 +94,13 @@ var emacsKeyBindings = []KeyBind{
 			buf.CursorRight(1)
 		},
 	},
+	// Alt Right allow: Forward one word
+	{
+		Key: AltRight,
+		Fn: func(buf *Buffer) {
+			buf.CursorRight(buf.Document().FindEndOfCurrentWordWithSpace())
+		},
+	},
 	// Left allow: Backward one character
 	{
 		Key: ControlB,
@@ -101,9 +108,22 @@ var emacsKeyBindings = []KeyBind{
 			buf.CursorLeft(1)
 		},
 	},
+	// Alt Left allow: Backward one word
+	{
+		Key: AltLeft,
+		Fn: func(buf *Buffer) {
+			buf.CursorLeft(len([]rune(buf.Document().TextBeforeCursor())) - buf.Document().FindStartOfPreviousWordWithSpace())
+		},
+	},
 	// Cut the Word before the cursor.
 	{
 		Key: ControlW,
+		Fn: func(buf *Buffer) {
+			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursorWithSpace())))
+		},
+	},
+	{
+		Key: AltBackspace,
 		Fn: func(buf *Buffer) {
 			buf.DeleteBeforeCursor(len([]rune(buf.Document().GetWordBeforeCursorWithSpace())))
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c-bata/go-prompt
 
-go 1.14
+go 1.22
 
 require (
 	github.com/mattn/go-colorable v0.1.7
@@ -9,3 +9,5 @@ require (
 	github.com/pkg/term v1.2.0-beta.2
 	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
 )
+
+require github.com/mattn/go-isatty v0.0.12 // indirect

--- a/input.go
+++ b/input.go
@@ -67,11 +67,14 @@ var ASCIISequences = []*ASCIICode{
 	{Key: ControlCircumflex, ASCIICode: []byte{0x1e}},
 	{Key: ControlUnderscore, ASCIICode: []byte{0x1f}},
 	{Key: Backspace, ASCIICode: []byte{0x7f}},
+	{Key: AltBackspace, ASCIICode: []byte{0x1b, 0x7f}},
 
 	{Key: Up, ASCIICode: []byte{0x1b, 0x5b, 0x41}},
 	{Key: Down, ASCIICode: []byte{0x1b, 0x5b, 0x42}},
 	{Key: Right, ASCIICode: []byte{0x1b, 0x5b, 0x43}},
+	{Key: AltRight, ASCIICode: []byte{0x1b, 0x1b, 0x5b, 0x43}},
 	{Key: Left, ASCIICode: []byte{0x1b, 0x5b, 0x44}},
+	{Key: AltLeft, ASCIICode: []byte{0x1b, 0x1b, 0x5b, 0x44}},
 	{Key: Home, ASCIICode: []byte{0x1b, 0x5b, 0x48}},
 	{Key: Home, ASCIICode: []byte{0x1b, 0x30, 0x48}},
 	{Key: End, ASCIICode: []byte{0x1b, 0x5b, 0x46}},
@@ -166,4 +169,8 @@ var ASCIISequences = []*ASCIICode{
 
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x45}}, // Xterm
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x46}}, // Linux console
+
+	// MacOS Keybind
+	{Key: AltRight, ASCIICode: []byte{0x1b, 0x66}},
+	{Key: AltLeft, ASCIICode: []byte{0x1b, 0x62}},
 }

--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term
@@ -25,5 +26,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term
@@ -15,13 +16,13 @@ var (
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (*unix.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
 		saveTermios, err = termios.Tcgetattr(uintptr(fd))
 	})
-	return saveTermios, err
+	return *saveTermios, err
 }
 
 // Restore terminal's mode.
@@ -30,5 +31,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
 }

--- a/key.go
+++ b/key.go
@@ -56,7 +56,9 @@ const (
 	Up
 	Down
 	Right
+	AltRight
 	Left
+	AltLeft
 
 	ShiftLeft
 	ShiftUp
@@ -73,6 +75,7 @@ const (
 	BackTab
 	Insert
 	Backspace
+	AltBackspace
 
 	// Aliases.
 	Tab


### PR DESCRIPTION
Added <kbd>Alt</kbd>+<kbd>←</kbd> and <kbd>Alt</kbd>+<kbd>→</kbd> processing to the contents of [this pull request](https://github.com/c-bata/go-prompt/pull/112).

For MacOS terminal emulators, <kbd>Option</kbd> + <kbd>delete</kbd> does not work with the default settings.
Therefore, it is necessary to enable the setting to use the Options key as the Meta key in each terminal.
This seems to be the same with zsh etc.