### PR TITLE
added new InputWithExit api to indicate when an exit was requested

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -231,6 +231,13 @@ func (p *Prompt) handleASCIICodeBinding(b []byte) bool {
 
 // Input just returns user input text.
 func (p *Prompt) Input() string {
+	input, _ := p.InputWithExit()
+
+	return input
+}
+
+// InputWithExit returns user input text along with a signal indicating if an exit was requested.
+func (p *Prompt) InputWithExit() (string, bool) {
 	defer debug.Teardown()
 	debug.Log("start prompt")
 	p.setUp()
@@ -251,11 +258,11 @@ func (p *Prompt) Input() string {
 			if shouldExit, e := p.feed(b); shouldExit {
 				p.renderer.BreakLine(p.buf)
 				stopReadBufCh <- struct{}{}
-				return ""
+				return "", shouldExit
 			} else if e != nil {
 				// Stop goroutine to run readBuffer function
 				stopReadBufCh <- struct{}{}
-				return e.input
+				return e.input, false
 			} else {
 				p.completion.Update(*p.buf.Document())
 				p.renderer.Render(p.buf, p.completion)


### PR DESCRIPTION
The idea here is to allow a bit finer grained control over the `Input` function without disturbing the current API.  When using `go-prompt` in a custom REPL it's useful to know when something like `CTRL+D` was pressed so that the loop can terminate, since there's no way to distinguish between empty input `""` and an exit request.  For your consideration.