### PR TITLE
Fix #266 correctly restore terminal parameters

### DIFF
--- a/input_posix.go
+++ b/input_posix.go
@@ -13,8 +13,7 @@ const maxReadBytes = 1024
 
 // PosixParser is a ConsoleParser implementation for POSIX environment.
 type PosixParser struct {
-	fd          int
-	origTermios syscall.Termios
+	fd int
 }
 
 // Setup should be called before starting input

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -11,17 +11,17 @@ import (
 
 var (
 	saveTermios     *unix.Termios
+	saveTermiosErr  error
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
 func getOriginalTermios(fd int) (*unix.Termios, error) {
-	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
-		saveTermios, err = termios.Tcgetattr(uintptr(fd))
+		saveTermios, saveTermiosErr = termios.Tcgetattr(uintptr(fd))
 	})
-	return saveTermios, err
+	return saveTermios, saveTermiosErr
 }
 
 // Restore terminal's mode.


### PR DESCRIPTION
Fixes #266

Also fixes issue where error within `getOriginalTermios` would not be persisted.