### PR TITLE
fix(render): guard toPos / lineWrap against zero terminal column count

### DIFF
--- a/render.go
+++ b/render.go
@@ -266,11 +266,20 @@ func (r *Render) move(from, to int) int {
 // toPos returns the relative position from the beginning of the string.
 func (r *Render) toPos(cursor int) (x, y int) {
 	col := int(r.col)
+	// A size-0 terminal column count (seen when UpdateWinSize has not
+	// yet been called, or when the TTY reports no size at all, e.g.
+	// under some CI runners or piped-in input) used to trip 'integer
+	// divide by zero' on the next keystroke (#277). Treat it as a
+	// single column so the prompt renders on the first row and
+	// recovers cleanly when the real size arrives.
+	if col <= 0 {
+		col = 1
+	}
 	return cursor % col, cursor / col
 }
 
 func (r *Render) lineWrap(cursor int) {
-	if runtime.GOOS != "windows" && cursor > 0 && cursor%int(r.col) == 0 {
+	if runtime.GOOS != "windows" && cursor > 0 && int(r.col) > 0 && cursor%int(r.col) == 0 {
 		r.out.WriteRaw([]byte{'\n'})
 	}
 }


### PR DESCRIPTION
## What

Fixes #277.

`Render.toPos` divided `cursor` by `r.col` without a zero check. When the terminal reported a zero column count - `UpdateWinSize` not yet called, CI runner with no TTY, input piped in, or `ioctl` returning zero for any other reason - the first keystroke path hit `panic: runtime error: integer divide by zero` and crashed the host process.

## Fix

- `toPos`: clamp `col` to a minimum of 1 so the prompt still renders on the first row.
- `lineWrap`: add the same guard before the `cursor % r.col == 0` check so the newline branch cannot fire the same crash.

Once the real window size arrives via SIGWINCH or a manual `UpdateWinSize` call, subsequent keystrokes behave exactly as before.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l`: clean
- `go vet ./...`: clean
- `go test -race -count=1 ./...`: all packages pass

Closes #277